### PR TITLE
yaml objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "esbuild": "^0.16.11",
     "esbuild-plugin-inline-worker": "https://github.com/mitschabaude/esbuild-plugin-inline-worker",
     "jest": "^27.1.0",
-    "obsidian": "^1.1.0",
+    "obsidian": "^1.1.1",
     "prettier": "2.3.2",
     "ts-jest": "^27.0.5",
     "tslib": "^2.3.1",
@@ -51,6 +51,7 @@
     "luxon": "^2.4.0",
     "parsimmon": "^1.18.0",
     "preact": "^10.17.1",
-    "sorted-btree": "^1.8.1"
+    "sorted-btree": "^1.8.1",
+    "yaml": "^2.3.3"
   }
 }

--- a/src/index/import/markdown.ts
+++ b/src/index/import/markdown.ts
@@ -406,7 +406,6 @@ function isLinkObject(inobj: any): boolean {
 }
 /** recursively parse yaml links and return them as a single array */
 export function parseYAMLLinks(obj: any): Link[] {
-    const log = (a: any, k: string) => console.log(`[YAML/import] | ${k}`, a);
 
     let links: Link[] = [];
     if(isLinkObject(obj)) {
@@ -416,11 +415,9 @@ export function parseYAMLLinks(obj: any): Link[] {
     for (let v in obj) {
         let obj2 = parseFrontmatter(obj[v]);
         let asany = obj2 as any;
-        log(obj2, "top");
         if (typeof obj2 === "object") {
             if (Array.isArray(obj2)) {
                 let result = obj2.map((child) => parseFrontmatter(child));
-                log(result, "res");
                 for (let c of result) {
                     if(typeof c === "object" && (c as any).value) {
                         parseYAMLLinks(c).forEach((n) => addLink(links, Link.fromObject(n)))

--- a/src/index/import/markdown.ts
+++ b/src/index/import/markdown.ts
@@ -1,7 +1,8 @@
 import { Link } from "expression/link";
 import { getFileTitle } from "utils/normalizers";
 import { DateTime } from "luxon";
-import { CachedMetadata, FileStats, ListItemCache, parseYaml } from "obsidian";
+import { CachedMetadata, FileStats, ListItemCache } from "obsidian";
+import { parse as parseYaml } from "yaml";
 import BTree from "sorted-btree";
 import { InlineField, asInlineField, extractFullLineField, extractInlineFields } from "./inline-field";
 import { EXPRESSION } from "expression/parser";

--- a/src/index/types/markdown/json.ts
+++ b/src/index/types/markdown/json.ts
@@ -1,6 +1,7 @@
 //! Note: These are "serialization" types for datacore metadata, which contain
 // the absolute minimum information needed to save and load datacore data.
 
+import { Field } from "expression/field";
 import { Link, Literal } from "expression/literal";
 import { InlineField } from "index/import/inline-field";
 
@@ -127,4 +128,11 @@ export interface JsonMarkdownTaskItem extends JsonMarkdownListItem {
 
     /** The text inside of the task item. */
     $status: string;
+}
+
+
+export interface JsonMarkdownYamlObject extends JsonMarkdownBlock {
+    $type: "yaml-data";
+    /** top level fields in the YAML object */
+    $fields: Field[];
 }

--- a/src/index/types/markdown/markdown.ts
+++ b/src/index/types/markdown/markdown.ts
@@ -282,6 +282,8 @@ export class MarkdownBlock implements Indexable, Linkbearing, Taggable, Fieldbea
     static from(object: JsonMarkdownBlock, file: string, normalizer: LinkNormalizer = NOOP_NORMALIZER): MarkdownBlock {
         if (object.$type === "list") {
             return MarkdownListBlock.from(object as JsonMarkdownListBlock, file, normalizer);
+        } else if(object.$type === "yaml-data") {
+            return MarkdownYAMLBlock.from(object as JsonMarkdownYamlObject, file, normalizer)
         }
 
         return new MarkdownBlock({
@@ -539,7 +541,7 @@ export class MarkdownTaskItem extends MarkdownListItem implements Indexable, Lin
     }
 }
 
-export class MarkdownYAMLBlock extends MarkdownBlock implements Indexable, Fieldbearing {
+export class MarkdownYAMLBlock extends MarkdownBlock implements Indexable, Fieldbearing, Linkbearing {
     static TYPES = ["markdown", "block", "inline-yaml", TAGGABLE_TYPE, LINKBEARING_TYPE, FIELDBEARING_TYPE];
 
     $types: string[] = MarkdownYAMLBlock.TYPES;
@@ -554,6 +556,8 @@ export class MarkdownYAMLBlock extends MarkdownBlock implements Indexable, Field
 
     public constructor(init: Partial<MarkdownYAMLBlock>) {
         super(init);
+        Object.assign(this, init);
+        this.$typename = "YAML"
     }
 
     static from(object: JsonMarkdownYamlObject, file: string, normalizer: LinkNormalizer = NOOP_NORMALIZER): MarkdownYAMLBlock {
@@ -565,6 +569,7 @@ export class MarkdownYAMLBlock extends MarkdownBlock implements Indexable, Field
             $ordinal: object.$ordinal,
             $fields: object.$fields,
             $links: object.$links.map(normalizer),
+            $typename: "YAML",
             $tags: object.$tags,
             $type: "yaml-data",
             $blockId: object.$blockId,

--- a/src/index/types/markdown/markdown.ts
+++ b/src/index/types/markdown/markdown.ts
@@ -542,7 +542,7 @@ export class MarkdownTaskItem extends MarkdownListItem implements Indexable, Lin
 }
 
 export class MarkdownYAMLBlock extends MarkdownBlock implements Indexable, Fieldbearing, Linkbearing {
-    static TYPES = ["markdown", "block", "inline-yaml", TAGGABLE_TYPE, LINKBEARING_TYPE, FIELDBEARING_TYPE];
+    static TYPES = ["markdown", "block", "yaml-data", TAGGABLE_TYPE, LINKBEARING_TYPE, FIELDBEARING_TYPE];
 
     $types: string[] = MarkdownYAMLBlock.TYPES;
     $typename: string = "YAML";

--- a/src/index/types/markdown/markdown.ts
+++ b/src/index/types/markdown/markdown.ts
@@ -23,6 +23,7 @@ import {
     JsonMarkdownListBlock,
     JsonMarkdownListItem,
     JsonMarkdownTaskItem,
+    JsonMarkdownYamlObject,
 } from "./json";
 
 /** A link normalizer which takes in a raw link and produces a normalized link. */
@@ -535,6 +536,45 @@ export class MarkdownTaskItem extends MarkdownListItem implements Indexable, Lin
     /** Determine if the given task is completed. */
     public get $completed() {
         return this.$status === "x" || this.$status === "X";
+    }
+}
+
+export class MarkdownYAMLBlock extends MarkdownBlock implements Indexable, Fieldbearing {
+    static TYPES = ["markdown", "block", "inline-yaml", TAGGABLE_TYPE, LINKBEARING_TYPE, FIELDBEARING_TYPE];
+
+    $types: string[] = MarkdownYAMLBlock.TYPES;
+    $typename: string = "YAML";
+    $id: string;
+    $file: string;
+    $position: LineSpan;
+    $blockId?: string;
+    $type: "yaml-data";
+    $fields: Field[];
+
+
+    public constructor(init: Partial<MarkdownYAMLBlock>) {
+        super(init);
+    }
+
+    static from(object: JsonMarkdownYamlObject, file: string, normalizer: LinkNormalizer = NOOP_NORMALIZER): MarkdownYAMLBlock {
+        return new MarkdownYAMLBlock({
+            $file: file,
+            $id: MarkdownYAMLBlock.readableId(file, object.$position.start),
+            $position: object.$position,
+            $infields: object.$infields,
+            $ordinal: object.$ordinal,
+            $fields: object.$fields,
+            $links: object.$links.map(normalizer),
+            $tags: object.$tags,
+            $type: "yaml-data",
+            $blockId: object.$blockId,
+        })
+    }
+    get fields() {
+        return this.$fields;
+    }
+    static readableId(file: string, line: number): string {
+        return `${file}/yaml${line}`;
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -739,10 +739,10 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
-"@types/codemirror@5.60.8":
-  version "5.60.8"
-  resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-5.60.8.tgz#b647d04b470e8e1836dd84b2879988fc55c9de68"
-  integrity sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==
+"@types/codemirror@0.0.108":
+  version "0.0.108"
+  resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-0.0.108.tgz#e640422b666bf49251b384c390cdeb2362585bde"
+  integrity sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==
   dependencies:
     "@types/tern" "*"
 
@@ -2301,12 +2301,12 @@ object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
-obsidian@^1.1.0:
-  version "1.4.11"
-  resolved "https://registry.yarnpkg.com/obsidian/-/obsidian-1.4.11.tgz#5cba594c83a74ebad58b630c610265018abdadaa"
-  integrity sha512-BCVYTvaXxElJMl6MMbDdY/CGK+aq18SdtDY/7vH8v6BxCBQ6KF4kKxL0vG9UZ0o5qh139KpUoJHNm+6O5dllKA==
+obsidian@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/obsidian/-/obsidian-1.1.1.tgz#7cce6f19a6dd1cc5ec7e9f7dff8ea3ceacf2e2c3"
+  integrity sha512-GcxhsHNkPEkwHEjeyitfYNBcQuYGeAHFs1pEpZIv0CnzSfui8p8bPLm2YKLgcg20B764770B1sYGtxCvk9ptxg==
   dependencies:
-    "@types/codemirror" "5.60.8"
+    "@types/codemirror" "0.0.108"
     moment "2.29.4"
 
 once@^1.3.0:
@@ -2921,6 +2921,11 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.3.tgz#01f6d18ef036446340007db8e016810e5d64aad9"
+  integrity sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==
 
 yargs-parser@20.x, yargs-parser@^20.2.2:
   version "20.2.9"


### PR DESCRIPTION
the markdown importer now checks for YAML codeblocks and inserts each key/value pair as fields. i've also added a respective indexer type in `index/types/markdown/markdown.ts`

as always, let me know if i should change anything ^-^