### PR TITLE
Fix blockOrdinal not incremented

### DIFF
--- a/src/index/import/markdown.ts
+++ b/src/index/import/markdown.ts
@@ -96,7 +96,7 @@ export function markdownImport(
 
         if (block.type === "list") {
             blocks.set(start, {
-                $ordinal: blockOrdinal,
+                $ordinal: blockOrdinal++,
                 $position: { start, end },
                 $tags: [],
                 $links: [],
@@ -124,7 +124,7 @@ export function markdownImport(
             }
 
             blocks.set(start, {
-                $ordinal: blockOrdinal,
+                $ordinal: blockOrdinal++,
                 $position: { start, end },
                 $tags: [],
                 $infields: {},
@@ -134,7 +134,7 @@ export function markdownImport(
             } as JsonMarkdownDatablock);
         } else {
             blocks.set(start, {
-                $ordinal: blockOrdinal,
+                $ordinal: blockOrdinal++,
                 $position: { start, end },
                 $tags: [],
                 $links: [],


### PR DESCRIPTION
Currently, every block in a `MarkdownPage` has the same id `.../block1` because the `blockOrdinal` variable is not incremented when importing blocks.

<img width="1552" alt="image" src="https://github.com/blacksmithgu/datacore/assets/72342591/f57e9759-f01b-4c15-8203-d3ca8a859e5c">

This PR fixes this. After this change, the block ids look fine.

<img width="1552" alt="image" src="https://github.com/blacksmithgu/datacore/assets/72342591/439185b1-012f-4a71-b37e-7d5c7d3d391b">

Please let me know if I should change anything. Thank you.