### PR TITLE
Fix links from a markdown block not properly unindexed

### DIFF
--- a/src/index/datastore.ts
+++ b/src/index/datastore.ts
@@ -212,7 +212,7 @@ export class Datastore {
             this.tags.delete(object.$id, extractSubtags(tags));
         }
 
-        if (object.$types.contains(LINKABLE_TYPE) && iterableExists(object, "$links")) {
+        if (object.$types.contains(LINKBEARING_TYPE) && iterableExists(object, "$links")) {
             // Assume links are normalized when deleting them. Could be broken but I hope not. We can always use a 2-way index to
             // fix this if we encounter non-normalized links.
             this.links.delete(


### PR DESCRIPTION
## Steps to reproduce

1. Create two notes "Source.md" and "Target.md". At this point, `datacore.core.datastore.links.get('Target.md')` (the backlinks to Target.md) is of course empty.

<img width="1552" alt="image" src="https://github.com/blacksmithgu/datacore/assets/72342591/aef57829-ada7-4a72-ae41-3bb444b2c253">

2. In Source.md, insert a link to Target.md. At this point, the backlinks are properly populated by three objects: the note Source.md (`MarkdownPage`), it first section (`MarkdownSection`), and the first block in this section (`MarkdownBlock`).

<img width="1552" alt="image" src="https://github.com/blacksmithgu/datacore/assets/72342591/d7efe701-99a2-4d31-88c6-7610006b7c3e">

3. Remove the link from Source.md to Targe.md. Now the problem occurs: two of the three objects are properly removed by `_unindex` method of `Datastore`, but `Source.md/block1` is not. It should get back to an empty set.

<img width="1552" alt="image" src="https://github.com/blacksmithgu/datacore/assets/72342591/78421198-2dce-4865-bac3-b279b882372b">

## Cause

This bug is caused by this line in `Datastore.prototype._unindex`, I think:
https://github.com/blacksmithgu/datacore/blob/5fdeb17522770fa75b6a4083c6d850e83c13a6b9/src/index/datastore.ts#L215

`MarkdownPage` and `MarkdownSection` are linkable, so they can be properly unindexed. However, `MarkdownBlock` is not linkable. This is why the unindexing was skipped for `Source.md/block1`.

## Solution

I think `LINKABLE_TYPE` in the first condition should instead be `LINKBEARING_TYPE` because we need `$links` here, not `$link`.

## Result

After this modification, everything looks fine:

1.
<img width="1552" alt="image" src="https://github.com/blacksmithgu/datacore/assets/72342591/cdf58218-06c2-4f97-9743-4f936e1edf82">

2.
<img width="1552" alt="image" src="https://github.com/blacksmithgu/datacore/assets/72342591/3338ed70-8ac3-4db2-93a1-229c59ad4ec9">

3.
<img width="1552" alt="image" src="https://github.com/blacksmithgu/datacore/assets/72342591/942e4417-9025-4c01-ad36-4809d5c4e749">
