### PR TITLE
Fix emptyLines always returning false

### DIFF
--- a/src/index/import/markdown.ts
+++ b/src/index/import/markdown.ts
@@ -317,7 +317,7 @@ function emptylines(lines: string[], start: number, end: number): boolean {
         if (lines[index].trim() !== "") return false;
     }
 
-    return false;
+    return true;
 }
 
 /**


### PR DESCRIPTION
This is a very simple, minor error, but prevented any markdown file that has its first heading at line zero, for example:

```md
# Heading

> [!NOTE]
> Hello, world
```

because this `if` condition is always satisfied as long as there is at least one heading.
https://github.com/blacksmithgu/datacore/blob/5fdeb17522770fa75b6a4083c6d850e83c13a6b9/src/index/import/markdown.ts#L67

In this case, the section with `$ordinal == 0` should not be created, but it is created and it overwrites the original section with `$ordinal == 1`.