### PR TITLE
Swap to synchronous query hooks

### DIFF
--- a/src/api/local-api.ts
+++ b/src/api/local-api.ts
@@ -6,11 +6,12 @@ import { IndexQuery } from "index/types/index-query";
 import { Indexable } from "index/types/indexable";
 import { MarkdownPage } from "index/types/markdown/markdown";
 import { App } from "obsidian";
-import { UseQueryResult, useFileMetadata, useFullQuery, useInterning, useQuery } from "ui/hooks";
+import { useFileMetadata, useFullQuery, useInterning, useQuery } from "ui/hooks";
 import * as luxon from "luxon";
 import * as preact from "preact";
 import * as hooks from "preact/hooks";
 import { useTableDispatch } from "ui/table";
+import { DataArray } from "./data-array";
 
 /** Local API provided to specific codeblocks when they are executing. */
 export class DatacoreLocalApi {
@@ -90,13 +91,15 @@ export class DatacoreLocalApi {
      * Run a query, automatically re-running it whenever the vault changes. Returns more information about the query
      * execution, such as index revision and total search duration.
      */
-    public useFullQuery(query: IndexQuery, settings?: { debounce?: number }): UseQueryResult<SearchResult<Indexable>> {
+    public useFullQuery(query: IndexQuery, settings?: { debounce?: number }): SearchResult<Indexable> {
         return useFullQuery(this.core, query, settings);
     }
 
     /** Run a query, automatically re-running it whenever the vault changes. */
-    public useQuery(query: IndexQuery, settings?: { debounce?: number }): UseQueryResult<Indexable[]> {
-        return useQuery(this.core, query, settings);
+    public useQuery(query: IndexQuery, settings?: { debounce?: number }): DataArray<Indexable> {
+        // Hooks need to be called in a consistent order, so we don't nest the `useQuery` call in the DataArray.wrap _just_ in case.
+        const result = useQuery(this.core, query, settings);
+        return DataArray.wrap(result);
     }
 
     //////////////////////////

--- a/src/expression/literal.ts
+++ b/src/expression/literal.ts
@@ -168,12 +168,20 @@ export namespace Literals {
         }
     }
 
+    /** Check if two arbitrary literals are equal. */
+    export function equals(first: Literal | undefined, second: Literal | undefined) {
+        return compare(first, second) == 0;
+    }
+
     /** Compare two arbitrary JavaScript values. Produces a total ordering over ANY possible datacore value. */
     export function compare(
         val1: Literal | undefined,
         val2: Literal | undefined,
         linkNormalizer?: (link: string) => string
     ): number {
+        // Reference equality - short circuit.
+        if (val1 === val2) return 0;
+
         // Handle undefined/nulls first.
         if (val1 === undefined) val1 = null;
         if (val2 === undefined) val2 = null;

--- a/src/ui/hooks.ts
+++ b/src/ui/hooks.ts
@@ -100,7 +100,7 @@ export function useFullQuery(
     query: IndexQuery,
     settings?: UseQuerySettings
 ): SearchResult<Indexable> {
-    return tryUseFullQuery(datacore, query, settings).orElseThrow(e => "Failed to search: " + e);
+    return tryUseFullQuery(datacore, query, settings).orElseThrow((e) => "Failed to search: " + e);
 }
 
 /** Simplier version of useFullQuery which just directly returns results. */
@@ -113,11 +113,7 @@ export function tryUseQuery(
 }
 
 /** Simplier version of useFullQuery which just directly returns results. */
-export function useQuery(
-    datacore: Datacore,
-    query: IndexQuery,
-    settings?: UseQuerySettings
-): Indexable[] {
+export function useQuery(datacore: Datacore, query: IndexQuery, settings?: UseQuerySettings): Indexable[] {
     return useFullQuery(datacore, query, settings).results;
 }
 


### PR DESCRIPTION
No point in making the API suck and be async when there are no async searches yet.