### PR TITLE
Add href to <a> that RawLink returns

### DIFF
--- a/src/ui/markdown.tsx
+++ b/src/ui/markdown.tsx
@@ -75,6 +75,7 @@ export function RawLink({ link, sourcePath: maybeSourcePath }: { link: Link | st
             rel="noopener"
             data-tooltip-position="top"
             data-href={parsed.obsidianLink()}
+            href={parsed.obsidianLink()}
         >
             {parsed.displayOrDefault()}
         </a>


### PR DESCRIPTION
Without `href`, you can't drag links into the note.