### PR TITLE
feat: Track file access time, new hook based on access time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 
 # Build artifacts.
 build/
+dist/
 
 # Various editor preferences.
 .vscode
@@ -18,4 +19,4 @@ build/
 
 docs/root/api/**/*.*
 !docs/root/api/index.md
-.docuaurus/
+.docusaurus/

--- a/src/api/local-api.tsx
+++ b/src/api/local-api.tsx
@@ -9,7 +9,7 @@ import { IndexQuery } from "index/types/index-query";
 import { Indexable } from "index/types/indexable";
 import { MarkdownPage } from "index/types/markdown";
 import { App } from "obsidian";
-import { useFileMetadata, useFullQuery, useIndexUpdates, useInterning, useQuery } from "ui/hooks";
+import { useFileMetadata, useFullQuery, useIndexUpdates, useInterning, useQuery, useLastOpenedFiles } from "ui/hooks";
 import * as luxon from "luxon";
 import * as preact from "preact";
 import * as hooks from "preact/hooks";
@@ -180,6 +180,13 @@ export class DatacoreLocalApi {
     /** Use the file metadata for a specific file. Automatically updates the view when the file changes. */
     public useFile(path: string, settings?: { debounce?: number }): Indexable | undefined {
         return useFileMetadata(this.core, path, settings)!;
+    }
+
+    /** Get the list of opened files. Defaults the 10 most recent files. Can be overridden by setting `settings.limit` to
+     * the desired amount.
+     */
+    public useLastOpenedFiles(settings?: { limit?: number; debounce?: number }): Indexable[] {
+        return useLastOpenedFiles(this.core, settings);
     }
 
     /** Automatically refresh the view whenever the index updates; returns the latest index revision ID. */

--- a/src/index/types/canvas.ts
+++ b/src/index/types/canvas.ts
@@ -34,6 +34,7 @@ export class Canvas implements Linkable, File, Linkbearing, Taggable, Indexable,
     $types: string[] = Canvas.TYPES;
     $typename: string = "Canvas";
 
+    $atime?: DateTime;
     $ctime: DateTime;
     $mtime: DateTime;
 
@@ -75,6 +76,7 @@ export class Canvas implements Linkable, File, Linkbearing, Taggable, Indexable,
             $cards: this.$cards.map((x) => x.json()) as JsonCanvasCard[],
             $ctime: this.$ctime.toMillis(),
             $mtime: this.$mtime.toMillis(),
+            $atime: this.$atime?.toMillis(),
             $size: this.$size,
             $links: this.$links,
             $path: this.$path,
@@ -101,6 +103,7 @@ export class Canvas implements Linkable, File, Linkbearing, Taggable, Indexable,
             $cards: cards,
             $ctime: DateTime.fromMillis(raw.$ctime),
             $mtime: DateTime.fromMillis(raw.$mtime),
+            $atime: raw.$atime ? DateTime.fromMillis(raw.$atime) : undefined,
             $size: raw.$size,
             $extension: "canvas",
             $path: raw.$path,

--- a/src/index/types/files.ts
+++ b/src/index/types/files.ts
@@ -19,15 +19,18 @@ export class GenericFile implements File, Indexable, Fieldbearing, Linkable {
     $ctime: DateTime;
     /** Obsidian-provided date this page was modified. */
     $mtime: DateTime;
+    /** Timestamp of last file access, as determined by inspecting `file-open` workspace events */
+    $atime?: DateTime;
     /** Obsidian-provided size of this page in bytes. */
     $size: number;
     /** The extension of the file. */
     $extension: string;
 
-    public constructor(path: string, ctime: DateTime, mtime: DateTime, size: number) {
+    public constructor(path: string, ctime: DateTime, mtime: DateTime, size: number, atime?: DateTime) {
         this.$path = path;
         this.$ctime = ctime;
         this.$mtime = mtime;
+        this.$atime = atime;
         this.$size = size;
 
         const lastDot = path.lastIndexOf(".");

--- a/src/index/types/indexable.ts
+++ b/src/index/types/indexable.ts
@@ -32,6 +32,14 @@ export interface Linkable {
     $link: Link;
 }
 
+export function isLinkable(obj: any): obj is Linkable {
+    if (obj && obj.$types !== undefined && Array.isArray(obj.$types) && obj.$types.contains(LINKABLE_TYPE)) {
+        return true;
+    }
+
+    return false;
+}
+
 /** General metadata for any file. */
 export const FILE_TYPE = "file";
 /**
@@ -52,6 +60,14 @@ export interface File extends Linkable {
     $extension: string;
 }
 
+export function isFile(obj: any): obj is File {
+    if (obj && obj.$types !== undefined && Array.isArray(obj.$types) && obj.$types.contains(FILE_TYPE)) {
+        return true;
+    }
+
+    return false;
+}
+
 /** Metadata for taggable objects. */
 export const TAGGABLE_TYPE = "taggable";
 /**
@@ -62,6 +78,14 @@ export interface Taggable {
     $tags: string[];
 }
 
+export function isTaggable(obj: any): obj is Taggable {
+    if (obj && obj.$types !== undefined && Array.isArray(obj.$types) && obj.$types.contains(TAGGABLE_TYPE)) {
+        return true;
+    }
+
+    return false;
+}
+
 /** Metadata for objects which can link to other things. */
 export const LINKBEARING_TYPE = "links";
 /**
@@ -70,6 +94,14 @@ export const LINKBEARING_TYPE = "links";
 export interface Linkbearing {
     /** The links in this file. */
     $links: Link[];
+}
+
+export function isLinkbearing(obj: any): obj is Linkbearing {
+    if (obj && obj.$types !== undefined && Array.isArray(obj.$types) && obj.$types.contains(LINKBEARING_TYPE)) {
+        return true;
+    }
+
+    return false;
 }
 
 /**

--- a/src/index/types/indexable.ts
+++ b/src/index/types/indexable.ts
@@ -44,6 +44,8 @@ export interface File extends Linkable {
     $ctime: DateTime;
     /** Obsidian-provided date this page was modified. */
     $mtime: DateTime;
+    /** Timestamp of last file access, as determined by inspecting `file-open` workspace events */
+    $atime?: DateTime;
     /** Obsidian-provided size of this page in bytes. */
     $size: number;
     /** The extension of the file. */

--- a/src/index/types/json/canvas.ts
+++ b/src/index/types/json/canvas.ts
@@ -36,6 +36,8 @@ export interface JsonCanvas {
     $ctime: number;
     /** Last modified time as a UNIX epoch time in milliseconds. */
     $mtime: number;
+    /** Last access time as a UNIX epoch time in milliseconds. */
+    $atime?: number;
     /** All tags in the canvas. */
     $tags: string[];
     /** All links in the canvas. */

--- a/src/index/types/json/markdown.ts
+++ b/src/index/types/json/markdown.ts
@@ -33,6 +33,8 @@ export interface JsonMarkdownPage {
     $ctime: number;
     /** Obsidian-provided date this page was modified. */
     $mtime: number;
+    /** Timestamp of last file access, as determined by inspecting `file-open` workspace events */
+    $atime?: number;
     /** The extension; for markdown files, almost always '.md'. */
     $extension: string;
     /** Obsidian-provided size of this page in bytes. */

--- a/src/index/types/markdown.ts
+++ b/src/index/types/markdown.ts
@@ -61,6 +61,8 @@ export class MarkdownPage implements File, Linkbearing, Taggable, Indexable, Fie
     $ctime: DateTime;
     /** Obsidian-provided date this page was modified. */
     $mtime: DateTime;
+    /** Timestamp of last file access, as determined by inspecting `file-open` workspace events */
+    $atime?: DateTime;
     /** The extension; for markdown files, almost always '.md'. */
     $extension: string;
     /** Obsidian-provided size of this page in bytes. */
@@ -89,6 +91,7 @@ export class MarkdownPage implements File, Linkbearing, Taggable, Indexable, Fie
             $infields: mapObjectValues(raw.$infields, (field) => normalizeLinks(valueInlineField(field), normalizer)),
             $ctime: DateTime.fromMillis(raw.$ctime),
             $mtime: DateTime.fromMillis(raw.$mtime),
+            $atime: raw.$atime ? DateTime.fromMillis(raw.$atime) : undefined,
             $extension: raw.$extension,
             $size: raw.$size,
             $position: raw.$position,
@@ -140,6 +143,7 @@ export class MarkdownPage implements File, Linkbearing, Taggable, Indexable, Fie
             $infields: mapObjectValues(this.$infields, jsonInlineField),
             $ctime: this.$ctime.toMillis(),
             $mtime: this.$mtime.toMillis(),
+            $atime: this.$atime?.toMillis(),
             $extension: this.$extension,
             $size: this.$size,
             $position: this.$position,


### PR DESCRIPTION
This PR adds a new optional intrinsic field `$atime?: DateTime` to the `File` interface, and updates the `MarkdownPage`, `Canvas`, and `GenericFile` implementations to conform. `$atime` is also added to the JSON representations for the above 3 classes:

- https://github.com/blacksmithgu/datacore/commit/d1e1c091e6e6d92c5783a398deed00dca1377a9e

Some type narrowing utilities for the `indexable` interfaces were added during this work to assist with satisfying the type checker:

- https://github.com/blacksmithgu/datacore/commit/68a044cf553a6e1a35940dceaffde134f00b98c7

We track `$atime` using the Obsidian Workspace `file-open` event:

- https://github.com/blacksmithgu/datacore/commit/a7ada90c73cabb3bc5aec912d0a826c123b4f18d

We also add a new hook, `useLastOpenedFiles`, for getting a list of the most recently accessed files via this new metadata:

- https://github.com/blacksmithgu/datacore/commit/40f4f2c951177247695f8d84be653c42e82dcf78