### PR TITLE
Trigger update event when file is deleted

### DIFF
--- a/src/index/datacore.ts
+++ b/src/index/datacore.ts
@@ -100,7 +100,9 @@ export class Datacore extends Component {
         this.registerEvent(
             this.vault.on("delete", (file) => {
                 if (file instanceof TFile) {
-                    this.datastore.delete(file.path);
+                    if (this.datastore.delete(file.path)) {
+                        this.trigger("update", this.revision);
+                    }
                 }
             })
         );


### PR DESCRIPTION
Fixes #82

Revision numbers are changed by `Datastore.delete(id)`:
https://github.com/blacksmithgu/datacore/blob/966f22896ec3cbb4f2160a049c2b2d072d276880/src/index/datastore.ts#L159-L167

Datacore should respond accordingly by triggering an update and rerendering views.

This makes it possible to track the number of notes in a TODO folder, for example:

````markdown
```datacorejsx
return function() {
    const count = dc.useQuery('@page and path("Brain Dump Folder")').length;
    return count === 1 ? "1 note" : `${count} notes`;
}
```
````