### PR TITLE
implement view pages 

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.4.0",
     "@fortawesome/free-solid-svg-icons": "^6.4.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
+    "@replit/codemirror-vim": "^6.3.0",
     "emoji-regex": "^10.2.1",
     "flatqueue": "^2.0.3",
     "localforage": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "localforage": "1.10.0",
     "luxon": "^2.4.0",
     "parsimmon": "^1.18.0",
-    "preact": "^10.17.1",
+    "preact": "^10.26.6",
     "react-select": "^5.10.1",
     "sorted-btree": "^1.8.1",
     "sucrase": "3.35.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   "license": "MIT",
   "devDependencies": {
     "@codemirror/autocomplete": "^6.18.6",
+    "@codemirror/commands": "^6.8.1",
     "@codemirror/language": "https://github.com/lishid/cm-language",
+    "@codemirror/search": "^6.5.10",
     "@codemirror/state": "^6.0.1",
     "@codemirror/view": "^6.0.1",
     "@microsoft/api-extractor": "^7.52.7",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "luxon": "^2.4.0",
     "parsimmon": "^1.18.0",
     "preact": "^10.17.1",
-    "react-select": "^5.8.0",
+    "react-select": "^5.10.1",
     "sorted-btree": "^1.8.1",
     "sucrase": "3.35.0",
     "yaml": "^2.3.3"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@codemirror/language": "https://github.com/lishid/cm-language",
     "@codemirror/search": "^6.5.10",
     "@codemirror/state": "^6.0.1",
-    "@codemirror/view": "^6.0.1",
+    "@codemirror/view": "^6.36.7",
     "@microsoft/api-extractor": "^7.52.7",
     "@types/jest": "^27.0.1",
     "@types/luxon": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "author": "Michael Brenan",
   "license": "MIT",
   "devDependencies": {
+    "@codemirror/autocomplete": "^6.18.6",
     "@codemirror/language": "https://github.com/lishid/cm-language",
     "@codemirror/state": "^6.0.1",
     "@codemirror/view": "^6.0.1",
@@ -45,6 +46,7 @@
     "typescript": "^5.4.2"
   },
   "dependencies": {
+    "@codemirror/lang-javascript": "^6.2.3",
     "@datastructures-js/queue": "^4.2.3",
     "@fortawesome/fontawesome-svg-core": "^6.4.0",
     "@fortawesome/free-solid-svg-icons": "^6.4.0",

--- a/select.d.ts
+++ b/select.d.ts
@@ -1,0 +1,19 @@
+
+declare module "react-select" {
+		import { RefAttributes, ReactElement, JSX } from "preact/compat";
+		import { StateManagerAdditionalProps } from "react-select/dist/declarations/src/useStateManager";
+		import { Props } from "react-select/dist/declarations/src/Select";
+		import Select from "react-select/dist/declarations/src/Select";
+		declare type StateManagedPropKeys = 'inputValue' | 'menuIsOpen' | 'onChange' | 'onInputChange' | 'onMenuClose' | 'onMenuOpen' | 'value';
+		declare type PublicBaseSelectProps<Option, IsMulti extends boolean, Group extends GroupBase<Option>> = JSX.LibraryManagedAttributes<typeof Select, Props<Option, IsMulti, Group>>;
+		declare type SelectPropsWithOptionalStateManagedProps<Option, IsMulti extends boolean, Group extends GroupBase<Option>> = Omit<PublicBaseSelectProps<Option, IsMulti, Group>, StateManagedPropKeys> & Partial<PublicBaseSelectProps<Option, IsMulti, Group>>;
+		export declare type StateManagerProps<Option = unknown, IsMulti extends boolean = boolean, Group extends GroupBase<Option> = GroupBase<Option>> = SelectPropsWithOptionalStateManagedProps<Option, IsMulti, Group> & StateManagerAdditionalProps<Option>;
+    declare const StateManagedSelect: <
+        Option = unknown,
+        IsMulti extends boolean = false,
+        Group extends GroupBase<Option> = GroupBase<Option>
+    >(
+        props: StateManagerProps<Option, IsMulti, Group>
+    ) =>  ReactElement;
+    export default StateManagedSelect;
+}

--- a/src/api/local-api.tsx
+++ b/src/api/local-api.tsx
@@ -29,6 +29,7 @@ import { Expression } from "expression/expression";
 import { Card } from "./ui/views/cards";
 import { ListView } from "./ui/views/list";
 import { Modal, Modals, SubmittableModal, useModalContext } from "./ui/views/modal";
+import * as obsidian from "obsidian";
 
 /**
  * Local API provided to specific codeblocks when they are executing.
@@ -96,6 +97,9 @@ export class DatacoreLocalApi {
      * ```
      */
     public async require(path: string | Link): Promise<unknown> {
+        if (typeof path === "string" && path === "obsidian") {
+            return Result.success(obsidian);
+        }
         const result = await this.scriptCache.load(path, { dc: this });
         return result.orElseThrow();
     }

--- a/src/api/local-api.tsx
+++ b/src/api/local-api.tsx
@@ -16,7 +16,7 @@ import * as hooks from "preact/hooks";
 import { Result } from "./result";
 import { Group, Stack } from "./ui/layout";
 import { Embed, LineSpanEmbed } from "api/ui/embed";
-import { CURRENT_FILE_CONTEXT, ErrorMessage, Lit, Markdown, ObsidianLink } from "ui/markdown";
+import { APP_CONTEXT, COMPONENT_CONTEXT, CURRENT_FILE_CONTEXT, DATACORE_CONTEXT, ErrorMessage, Lit, Markdown, ObsidianLink, SETTINGS_CONTEXT } from "ui/markdown";
 import { CSSProperties, Suspense } from "preact/compat";
 import { Literal, Literals } from "expression/literal";
 import { Button, Checkbox, Icon, Slider, Switch, Textbox, VanillaSelect } from "./ui/basics";
@@ -196,6 +196,25 @@ export class DatacoreLocalApi {
     public tryFullQuery<T extends Indexable = Indexable>(query: string | IndexQuery): Result<SearchResult<T>, string>;
     public tryFullQuery(query: string | IndexQuery): Result<SearchResult<Indexable>, string> {
         return this.api.tryFullQuery(query);
+		}
+    //////////////
+    // Contexts //
+    //////////////
+
+    // export the necessary contexts to enable rendering
+    // datacore components outside the datacore plugin
+    // itself
+    get SETTINGS_CONTEXT(): typeof SETTINGS_CONTEXT {
+        return SETTINGS_CONTEXT;
+    }
+    get COMPONENT_CONTEXT(): typeof COMPONENT_CONTEXT {
+        return COMPONENT_CONTEXT;
+    }
+    get DATACORE_CONTEXT(): typeof DATACORE_CONTEXT {
+        return DATACORE_CONTEXT;
+    }
+    get APP_CONTEXT(): typeof APP_CONTEXT {
+        return APP_CONTEXT;
     }
 
     /////////////

--- a/src/api/local-api.tsx
+++ b/src/api/local-api.tsx
@@ -299,7 +299,17 @@ export class DatacoreLocalApi {
         children: preact.ComponentChildren;
         fallback: preact.ComponentChild;
     }) {
-        return <>{loaded ? children : fallback}</>;
+        return (
+            <>
+                {loaded ? (
+                    children
+                ) : (
+                    <div className="datacore-loading-boundary">
+                        <div className="datacore-loading-content">{fallback}</div>
+                    </div>
+                )}
+            </>
+        );
     }
 
     /** Renders a literal value in a pretty way that respects settings. */

--- a/src/api/local-api.tsx
+++ b/src/api/local-api.tsx
@@ -17,7 +17,7 @@ import { Result } from "./result";
 import { Group, Stack } from "./ui/layout";
 import { Embed, LineSpanEmbed } from "api/ui/embed";
 import { CURRENT_FILE_CONTEXT, ErrorMessage, Lit, Markdown, ObsidianLink } from "ui/markdown";
-import { CSSProperties } from "preact/compat";
+import { CSSProperties, Suspense } from "preact/compat";
 import { Literal, Literals } from "expression/literal";
 import { Button, Checkbox, Icon, Slider, Switch, Textbox, VanillaSelect } from "./ui/basics";
 import { TableView } from "./ui/views/table";
@@ -287,30 +287,7 @@ export class DatacoreLocalApi {
     /** Horizontal flexbox container; good for putting items together in a row. */
     public Group = Group;
 
-    /** A component that only renders its children if `loaded` is true, otherwise defaulting to the `fallback` prop.
-     * Primarily intended to be used with `useAsync`.
-     */
-    public Suspend({
-        loaded: loaded,
-        children,
-        fallback,
-    }: {
-        loaded: boolean;
-        children: preact.ComponentChildren;
-        fallback: preact.ComponentChild;
-    }) {
-        return (
-            <>
-                {loaded ? (
-                    children
-                ) : (
-                    <div className="datacore-loading-boundary">
-                        <div className="datacore-loading-content">{fallback}</div>
-                    </div>
-                )}
-            </>
-        );
-    }
+   public Suspense = Suspense; 
 
     /** Renders a literal value in a pretty way that respects settings. */
     public Literal = (({ value, sourcePath, inline }: { value: Literal; sourcePath?: string; inline?: boolean }) => {

--- a/src/api/local-api.tsx
+++ b/src/api/local-api.tsx
@@ -9,7 +9,7 @@ import { IndexQuery } from "index/types/index-query";
 import { Indexable } from "index/types/indexable";
 import { MarkdownPage } from "index/types/markdown";
 import { App } from "obsidian";
-import { useFileMetadata, useFullQuery, useIndexUpdates, useInterning, useQuery } from "ui/hooks";
+import { useAsync, useFileMetadata, useFullQuery, useIndexUpdates, useInterning, useQuery } from "ui/hooks";
 import * as luxon from "luxon";
 import * as preact from "preact";
 import * as hooks from "preact/hooks";
@@ -226,6 +226,7 @@ export class DatacoreLocalApi {
      * React's reference-equality-based caching.
      */
     public useInterning = useInterning;
+    public useAsync = useAsync;
 
     /** Memoize the input automatically and process it using a DataArray; returns a vanilla array back. */
     public useArray<T, U>(
@@ -285,6 +286,21 @@ export class DatacoreLocalApi {
     public Stack = Stack;
     /** Horizontal flexbox container; good for putting items together in a row. */
     public Group = Group;
+
+    /** A component that only renders its children if `loaded` is true, otherwise defaulting to the `fallback` prop.
+     * Primarily intended to be used with `useAsync`.
+     */
+    public Suspend({
+        loaded: loaded,
+        children,
+        fallback,
+    }: {
+        loaded: boolean;
+        children: preact.ComponentChildren;
+        fallback: preact.ComponentChild;
+    }) {
+        return <>{loaded ? children : fallback}</>;
+    }
 
     /** Renders a literal value in a pretty way that respects settings. */
     public Literal = (({ value, sourcePath, inline }: { value: Literal; sourcePath?: string; inline?: boolean }) => {

--- a/src/api/local-api.tsx
+++ b/src/api/local-api.tsx
@@ -28,6 +28,7 @@ import { ScriptCache } from "./script-cache";
 import { Expression } from "expression/expression";
 import { Card } from "./ui/views/cards";
 import { ListView } from "./ui/views/list";
+import { Modal, Modals, SubmittableModal, useModalContext } from "./ui/views/modal";
 
 /**
  * Local API provided to specific codeblocks when they are executing.
@@ -36,6 +37,8 @@ import { ListView } from "./ui/views/list";
 export class DatacoreLocalApi {
     /** @internal The cache of all currently loaded scripts in this context. */
     private scriptCache: ScriptCache;
+
+		private modalTypes: Modals = new Modals();
 
     public constructor(public api: DatacoreApi, public path: string) {
         this.scriptCache = new ScriptCache(this.core.datastore);
@@ -388,6 +391,19 @@ export class DatacoreLocalApi {
 
         return <ErrorMessage message={`No valid embedding for element '${element.$id}' from '${element.$file}'`} />;
     }).bind(this);
+
+		/** Accessor for raw modal classes. */
+		public get modals() {
+			return this.modalTypes;
+		}
+
+		/** Wrapper around an obsidian modal. */
+		public Modal = Modal;
+
+		/** Wrapper around an obsidian modal that returns a result when submitted. */
+		public SubmittableModal = SubmittableModal;
+
+		public useModalContext = useModalContext;
 
     ///////////
     // Views //

--- a/src/api/ui/views/callout.tsx
+++ b/src/api/ui/views/callout.tsx
@@ -53,7 +53,7 @@ export function Callout({
             data-callout-metadata={type?.split(METADATA_SPLIT_REGEX)?.[1]}
             data-callout={type?.split(METADATA_SPLIT_REGEX)?.[0]}
             data-callout-fold={open ? "+" : "-"}
-            className={combineClasses("datacore", "callout", collapsible ? "is-collapsible" : undefined)}
+            className={combineClasses("datacore", "callout", collapsible ? "is-collapsible" : undefined, !open ? "is-collapsed" : undefined)}
         >
             <div className="callout-title" onClick={() => collapsible && setOpen(!open)}>
                 {icon && <div className="callout-icon">{icon}</div>}

--- a/src/api/ui/views/modal.tsx
+++ b/src/api/ui/views/modal.tsx
@@ -1,0 +1,126 @@
+import {
+    ReactNode,
+    RefObject,
+    forwardRef,
+    useContext,
+    createContext,
+    memo,
+    Context as ReactContext,
+    useEffect,
+    useRef,
+    createPortal,
+    ComponentProps,
+    ForwardedRef,
+    useImperativeHandle,
+    useMemo,
+} from "preact/compat";
+import { App, Modal as ObsidianModal } from "obsidian";
+import { APP_CONTEXT } from "ui/markdown";
+import { Literal } from "expression/literal";
+import { VNode } from "preact";
+
+class DatacoreModal extends ObsidianModal {
+    constructor(app: App, public openCallback?: ObsidianModal["onOpen"], public onCancel?: ObsidianModal["onClose"]) {
+        super(app);
+    }
+    public onOpen() {
+        super.onOpen();
+        this.openCallback?.();
+    }
+    public onClose() {
+        super.onClose();
+        this.onCancel?.();
+    }
+}
+
+class SubmittableDatacoreModal<T> extends DatacoreModal {
+    constructor(
+        app: App,
+        public submitCallback?: (result: T) => void | Promise<void>,
+        public openCallback?: ObsidianModal["onOpen"],
+        public onCancel?: ObsidianModal["onClose"]
+    ) {
+        super(app, openCallback, onCancel);
+    }
+    public onSubmit(result: T) {
+        this.close();
+        this.submitCallback?.(result);
+    }
+}
+
+export class Modals {
+    get submittableModal() {
+        return SubmittableDatacoreModal;
+    }
+    get modal() {
+        return DatacoreModal;
+    }
+}
+
+interface ModalContextType<M extends ObsidianModal> {
+    modal: M;
+}
+
+interface BaseModalProps {
+    title?: Literal | VNode | ReactNode;
+    children: ReactNode;
+    onCancel?: ObsidianModal["onClose"];
+    onOpen?: ObsidianModal["onOpen"];
+}
+
+const MODAL_CONTEXT = createContext<ModalContextType<any> | null>(null);
+
+function ModalContext<M extends ObsidianModal>({ modal, children }: { modal: M; children: ReactNode }) {
+    const Ctx = MODAL_CONTEXT as ReactContext<ModalContextType<M>>;
+    return <Ctx.Provider value={{ modal }}>{children}</Ctx.Provider>;
+}
+
+function useReusableImperativeHandle<M extends ObsidianModal>(modal: M, ref: ForwardedRef<M>) {
+    useImperativeHandle(ref, () => modal, [modal]);
+}
+
+function InnerSubmittableModal<T>(
+    {
+        children,
+        onSubmit,
+        onCancel,
+        onOpen,
+        title,
+    }: BaseModalProps & {
+        onSubmit?: (result: T) => void | Promise<void>;
+    },
+    ref: ForwardedRef<SubmittableDatacoreModal<T>>
+) {
+    const app = useContext(APP_CONTEXT)!;
+    const modal = useMemo(
+        () => new SubmittableDatacoreModal<T>(app, onSubmit, onOpen, onCancel),
+        [app, onSubmit, onOpen, onCancel]
+    );
+    useReusableImperativeHandle(modal, ref);
+    return (
+        <ModalContext modal={modal}>
+            {createPortal(<>{title}</>, modal.titleEl)}
+            {createPortal(<>{children}</>, modal.contentEl)}
+        </ModalContext>
+    );
+}
+
+function InnerModal({ children, onCancel, onOpen, title }: BaseModalProps, ref: ForwardedRef<DatacoreModal>) {
+    const app = useContext(APP_CONTEXT)!;
+    const modal = useMemo(() => new DatacoreModal(app, onOpen, onCancel), [app, onOpen, onCancel]);
+    useReusableImperativeHandle(modal, ref);
+    return (
+        <ModalContext modal={modal}>
+            {createPortal(<>{title}</>, modal.titleEl)}
+            {createPortal(<>{children}</>, modal.contentEl)}
+        </ModalContext>
+    );
+}
+
+export function useModalContext<M extends ObsidianModal>() {
+    return useContext(MODAL_CONTEXT) as ModalContextType<M>;
+}
+
+export const SubmittableModal = forwardRef(InnerSubmittableModal) as typeof InnerSubmittableModal;
+
+export const Modal = forwardRef(InnerModal) as typeof InnerModal;

--- a/src/api/ui/views/table-dispatch.ts
+++ b/src/api/ui/views/table-dispatch.ts
@@ -36,14 +36,21 @@ export function useTableDispatch(initial: TableState | (() => TableState)): [Tab
     return useReducer(tableReducer as Reducer<TableState, TableAction>, init);
 }
 
-export type TableContext = TableState & {
+export type CommonTableContext = TableState & {
 	dispatch: Dispatch<TableAction> 
+}
+
+export type TableContext = CommonTableContext & {
 } 
 
 export const TABLE_CONTEXT = createContext<TableContext | null>(null);
+
+export const COMMON_TABLE_CONTEXT = createContext<CommonTableContext | null>(null);
 
 export function useTableContext() {
 	return useContext(TABLE_CONTEXT);
 }
 
-
+export function useCommonTableContext() {
+	return useContext(COMMON_TABLE_CONTEXT);
+}

--- a/src/api/ui/views/table-dispatch.ts
+++ b/src/api/ui/views/table-dispatch.ts
@@ -1,0 +1,49 @@
+import { createContext } from "preact";
+import { Dispatch, useMemo, useReducer, Reducer, useContext } from "preact/hooks";
+
+/** The ways that the table can be sorted. */
+export type SortDirection = "ascending" | "descending";
+export type SortOn = { type: "column"; id: string; direction: SortDirection };
+
+export type TableAction = { type: "sort-column"; column: string; direction: SortDirection | undefined };
+
+export interface TableState {
+    /** mapping of column ids to sort directions */
+    sorts: Record<string, SortDirection>;
+}
+
+export function tableReducer(state: TableState, action: TableAction): TableState {
+    switch (action.type) {
+        case "sort-column": {
+					const newSorts = {...state.sorts};
+            if (action.direction === undefined) {
+							delete newSorts[action.column];
+            } else {
+                newSorts[action.column] = action.direction;
+            }
+            return {
+                ...state,
+							sorts: newSorts,
+            };
+        }
+    }
+    console.warn("datacore: Encountered unrecognized operation: " + (action as TableAction).type);
+    return state;
+}
+
+export function useTableDispatch(initial: TableState | (() => TableState)): [TableState, Dispatch<TableAction>] {
+    const init = useMemo(() => (typeof initial == "function" ? initial() : initial), []);
+    return useReducer(tableReducer as Reducer<TableState, TableAction>, init);
+}
+
+export type TableContext = TableState & {
+	dispatch: Dispatch<TableAction> 
+} 
+
+export const TABLE_CONTEXT = createContext<TableContext | null>(null);
+
+export function useTableContext() {
+	return useContext(TABLE_CONTEXT);
+}
+
+

--- a/src/api/ui/views/table.tsx
+++ b/src/api/ui/views/table.tsx
@@ -7,7 +7,7 @@ import { CURRENT_FILE_CONTEXT, Lit } from "ui/markdown";
 import { useAsElement, useInterning, useStableCallback } from "ui/hooks";
 import { Fragment } from "preact/jsx-runtime";
 import { faSortDown, faSortUp, faSort } from "@fortawesome/free-solid-svg-icons";
-import {useTableDispatch, type SortDirection, type SortOn, TABLE_CONTEXT, TableContext, useTableContext} from "./table-dispatch";
+import {useTableDispatch, type SortDirection, type SortOn, TABLE_CONTEXT, TableContext, useTableContext, CommonTableContext} from "./table-dispatch";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { PropsWithChildren, ReactNode } from "preact/compat";
@@ -304,7 +304,7 @@ export function SortButton({
 }: {
     className?: string;
 		columnId: string;
-		contextGetter?: () => TableContext | null;
+		contextGetter?: () => CommonTableContext | null;
 }) {
 		const {dispatch, ...state} = contextGetter()!;
 		const direction = state.sorts[columnId];

--- a/src/api/ui/views/table.tsx
+++ b/src/api/ui/views/table.tsx
@@ -300,11 +300,13 @@ export function TableRowCell<T>({ row, column }: { row: T; column: TableColumn<T
 export function SortButton({
 	columnId,
     className,
+	contextGetter = useTableContext,
 }: {
     className?: string;
 		columnId: string;
+		contextGetter?: () => TableContext | null;
 }) {
-		const {dispatch, ...state} = useTableContext()!;
+		const {dispatch, ...state} = contextGetter()!;
 		const direction = state.sorts[columnId];
     const icon = useMemo(() => {
         if (direction == "ascending") return faSortDown;

--- a/src/api/ui/views/table.tsx
+++ b/src/api/ui/views/table.tsx
@@ -325,8 +325,11 @@ export function SortButton({
 /** Default comparator for sorting on a table column. */
 export const DEFAULT_TABLE_COMPARATOR: <T>(a: Literal, b: Literal, ao: T, bo: T) => number = (a, b, _ao, _bo) =>
     Literals.compare(a, b);
-
-function TableContextProvider<T>({dispatch, children, ...rest}: PropsWithChildren<TableContext>) {	
+/**
+ * @hidden
+ * @group Components
+ */
+export function TableContextProvider<T>({dispatch, children, ...rest}: PropsWithChildren<TableContext>) {	
 	return <TABLE_CONTEXT.Provider value={{dispatch: dispatch, ...rest}}>
 		{children}
 	</TABLE_CONTEXT.Provider>

--- a/src/api/ui/views/table.tsx
+++ b/src/api/ui/views/table.tsx
@@ -4,13 +4,18 @@
 import { GroupElement, Grouping, Groupings, Literal, Literals } from "expression/literal";
 import { useContext, useMemo, useRef } from "preact/hooks";
 import { CURRENT_FILE_CONTEXT, Lit } from "ui/markdown";
-import { useAsElement, useInterning } from "ui/hooks";
+import { useAsElement, useInterning, useStableCallback } from "ui/hooks";
 import { Fragment } from "preact/jsx-runtime";
-import { ReactNode } from "preact/compat";
+import { faSortDown, faSortUp, faSort } from "@fortawesome/free-solid-svg-icons";
+import {useTableDispatch, type SortDirection, type SortOn, TABLE_CONTEXT, TableContext, useTableContext} from "./table-dispatch";
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { PropsWithChildren, ReactNode } from "preact/compat";
 
 import { ControlledPager, useDatacorePaging } from "./paging";
 
 import "./table.css";
+
 
 /**
  * A simple column definition which allows for custom renderers and titles.
@@ -33,6 +38,12 @@ export interface TableColumn<T, V = Literal> {
 
     /** Called to render the given column value. Can depend on both the specific value and the row object. */
     render?: (value: V, object: T) => Literal | ReactNode;
+
+		/** whether or not this column can be sorted on. */
+		sortable?: boolean;
+
+		/** comparator used when sorting this column. */
+		comparator?: (first: V, second: V, firstObject: T, secondObject: T) => number;
 }
 
 /**
@@ -69,6 +80,9 @@ export interface TableViewProps<T> {
      * If a number, will scroll only if the number is greater than the current page size.
      **/
     scrollOnPaging?: boolean | number;
+		
+    /** The fields to sort the view on, if relevant. */
+    sortOn?: SortOn[];
 }
 
 /**
@@ -94,12 +108,36 @@ export function TableView<T>(props: TableViewProps<T>) {
         elements: totalElements,
         container: tableRef,
     });
+		// Cache sorts by value equality and filter to only sortable valid fields.
+    const rawSorts = useInterning(props.sortOn, (a, b) => Literals.compare(a, b) == 0);
+		const [tableState, dispatch] = useTableDispatch(() => ({
+			sorts: Object.fromEntries((rawSorts?.filter((sort) => {
+            const column = columns.find((col) => col.id == sort.id);
+            return column && (column.sortable ?? true);
+        }) ?? []).map(a => [a.id, a.direction]))
+		}))
+		const idsToColumns = useMemo(() => {
+			return Object.fromEntries(columns.map(col => [col.id, col]));
+		}, [columns]);
+		const sortedRows = useMemo(() => {
+        if (tableState.sorts == undefined || Object.keys(tableState.sorts).length == 0) return props.rows;
+
+        const comparators = Object.entries(tableState.sorts).map(([id, direction]) => {
+            const col = idsToColumns[id];
+            const comp = col.comparator ? ((a: T, b: T) => col.comparator!(col?.value(a), col?.value(b), a, b)) : (a: T, b: T) => DEFAULT_TABLE_COMPARATOR(col.value(a), col.value(b), a, b);
+            return {
+                fn: comp,
+                direction: direction,
+            };
+        });
+        return Groupings.sort<T>(props.rows, comparators);
+    }, [props.rows, tableState.sorts, columns]);
 
     const pagedRows = useMemo(() => {
         if (paging.enabled)
-            return Groupings.slice(props.rows, paging.page * paging.pageSize, (paging.page + 1) * paging.pageSize);
-        else return props.rows;
-    }, [paging.page, paging.pageSize, paging.enabled, props.rows]);
+            return Groupings.slice(sortedRows, paging.page * paging.pageSize, (paging.page + 1) * paging.pageSize);
+        else return sortedRows;
+    }, [paging.page, paging.pageSize, paging.enabled, sortedRows]);
 
     const groupings = useMemo(() => {
         if (!props.groupings) return undefined;
@@ -110,6 +148,7 @@ export function TableView<T>(props: TableViewProps<T>) {
     }, [props.groupings]);
 
     return (
+      <TableContextProvider dispatch={dispatch} sorts={tableState.sorts}>
         <div ref={tableRef}>
             <table className="datacore-table">
                 <thead>
@@ -129,6 +168,7 @@ export function TableView<T>(props: TableViewProps<T>) {
                 <ControlledPager page={paging.page} totalPages={paging.totalPages} setPage={paging.setPage} />
             )}
         </div>
+      </TableContextProvider>
     );
 }
 
@@ -155,7 +195,10 @@ export function TableViewHeaderCell<T>({ column }: { column: TableColumn<T> }) {
     // We use an internal div to avoid flex messing with the table layout.
     return (
         <th style={{ width: realWidth }} className="datacore-table-header-cell">
-            <div className="datacore-table-header-title">{header}</div>
+						<div className="datacore-table-header-cell-content">
+							{column.sortable && <SortButton columnId={column.id} />}
+							<div className="datacore-table-header-title">{header}</div>
+						</div>
         </th>
     );
 }
@@ -253,3 +296,39 @@ export function TableRowCell<T>({ row, column }: { row: T; column: TableColumn<T
 
     return <td className="datacore-table-cell">{rendered}</td>;
 }
+
+export function SortButton({
+	columnId,
+    className,
+}: {
+    className?: string;
+		columnId: string;
+}) {
+		const {dispatch, ...state} = useTableContext()!;
+		const direction = state.sorts[columnId];
+    const icon = useMemo(() => {
+        if (direction == "ascending") return faSortDown;
+        else if (direction == "descending") return faSortUp;
+        return faSort;
+    }, [direction]);
+		const onClick = useStableCallback(() => {
+			dispatch({type: "sort-column", column: columnId, direction: direction == "ascending" ? "descending" : "ascending"});
+		}, [columnId, dispatch, state.sorts]);
+
+    return (
+        <div onClick={onClick} className={className}>
+            <FontAwesomeIcon icon={icon} />
+        </div>
+    );
+}
+
+/** Default comparator for sorting on a table column. */
+export const DEFAULT_TABLE_COMPARATOR: <T>(a: Literal, b: Literal, ao: T, bo: T) => number = (a, b, _ao, _bo) =>
+    Literals.compare(a, b);
+
+function TableContextProvider<T>({dispatch, children, ...rest}: PropsWithChildren<TableContext>) {	
+	return <TABLE_CONTEXT.Provider value={{dispatch: dispatch, ...rest}}>
+		{children}
+	</TABLE_CONTEXT.Provider>
+}
+

--- a/src/expression/literal.ts
+++ b/src/expression/literal.ts
@@ -411,6 +411,37 @@ export type Grouping<T> = T[] | GroupElement<T>[];
  * @hidden
  */
 export namespace Groupings {
+	/**
+	 * recursively sort a grouping
+	 */
+		export function sort<T>(rows: Grouping<T>, comparators: {
+			fn: (first: T, second: T) => number;
+			direction: "ascending" | "descending";
+		}[]): Grouping<T> {
+			const cmp = <E extends GroupElement<T> | T>(a: E, b: E): number => {
+				for(let comparator of comparators) {
+					let result: number = 0;
+          const direction = comparator.direction === "ascending" ? 1 : -1;
+					if(isElementGroup(a) && isElementGroup(b)) {
+						result = 0;
+					}	else if(!Groupings.isElementGroup(a) && !Groupings.isElementGroup(b)) {
+						result = direction * comparator.fn(a as T, b as T);
+					}
+					if(result != 0) return result;
+				}
+				return 0;
+			}
+			if(isLeaf(rows)) {	
+				return ([] as T[]).concat(rows).sort(cmp);
+			}	
+			const sortMapper = (item: GroupElement<T> | T): (GroupElement<T> | T) => {
+				if(isElementGroup(item)) {
+					return {key: item.key, rows: ([] as any).concat(item.rows).sort(cmp).map(sortMapper)}
+				}
+				return item
+			}
+			return ([] as GroupElement<T>[]).concat(rows).sort(cmp).map(sortMapper) as any;
+		}
     /** Determines if the given group entry is a standalone value, or a grouping of sub-entries. */
     export function isElementGroup<T>(entry: unknown): entry is GroupElement<T> {
         return Literals.isObject(entry) && Object.keys(entry).length == 2 && "key" in entry && "rows" in entry;

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { Datacore } from "index/datacore";
 import { DateTime } from "luxon";
 import { App, Plugin, PluginSettingTab, Setting } from "obsidian";
 import { DEFAULT_SETTINGS, Settings } from "settings";
+import { DatacoreQueryView as DatacoreJSView, VIEW_TYPE_DATACOREJS } from "ui/view-page";
 
 /** @internal Reactive data engine for your Obsidian.md vault. */
 export default class DatacorePlugin extends Plugin {
@@ -55,6 +56,20 @@ export default class DatacorePlugin extends Plugin {
             callback: async () => {
                 console.log("Datacore: dropping the datastore and reindexing all items.");
                 await this.core.reindex();
+						},
+        });
+        // Views: DatacoreJS view.
+        // @ts-ignore be quiet
+        this.registerView(VIEW_TYPE_DATACOREJS, (leaf) => new DatacoreJSView(leaf, this.api));
+
+        // Add a command for creating a new view page.
+        this.addCommand({
+            id: "datacore-add-view-page",
+            name: "Create View Page",
+            callback: () => {
+                const newLeaf = this.app.workspace.getLeaf("tab");
+                newLeaf.setViewState({ type: VIEW_TYPE_DATACOREJS, active: true });
+                this.app.workspace.setActiveLeaf(newLeaf, { focus: true });
             },
         });
 

--- a/src/typings/obsidian-ex.d.ts
+++ b/src/typings/obsidian-ex.d.ts
@@ -1,10 +1,49 @@
 import type { DatacorePlugin } from "main";
-import type { CanvasMetadataIndex } from "index/types/json/canvas";
-
+import { Extension } from "@codemirror/state";
+import type { DatacoreApi } from "api/api";
+import { CanvasMetadataIndex } from "index/types/json/canvas";
 import "obsidian";
+import { App } from "obsidian";
+import * as hooks from "preact/hooks";
 
 /** Provides extensions used by datacore or provider to other plugins via datacore. */
 declare module "obsidian" {
+    interface WorkspaceLeaf {
+        serialize(): {
+            id: string;
+            type: "leaf";
+            state: {
+                type: string;
+                state: any;
+            };
+        };
+        tabHeaderEl: HTMLElement;
+        tabHeaderInnerTitleEl: HTMLElement;
+    }
+    interface View {
+        getState(): any;
+    }
+    interface ItemView {
+        titleEl: HTMLElement;
+        getState(): any;
+    }
+
+    interface InternalPlugin<T> {
+        id: string;
+        name: string;
+        description: string;
+        instance: T;
+    }
+    export interface PagePreviewPlugin {
+        onLinkHover: (
+            view: View,
+            hovered: HTMLElement,
+            hoveredPath: string,
+            sourcePath: string,
+            _unknown: unknown
+        ) => void;
+    }
+
     interface FileManager {
         linkUpdaters?: {
             canvas?: {
@@ -16,15 +55,25 @@ declare module "obsidian" {
             };
         };
     }
-
+    interface Vault {
+        getConfig: (conf: string) => any;
+    }
     interface App {
         appId?: string;
 
         plugins: {
             enabledPlugins: Set<string>;
             plugins: {
-                datacore?: DatacorePlugin;
+                datacore?: {
+                    api: DatacoreApi;
+                };
+                "datacore-addon-autocomplete"?: {
+                    readonly extensions: Extension[];
+                };
             };
+        };
+        internalPlugins: {
+            getPluginById: <T>(id: string) => InternalPlugin<T>;
         };
 
         embedRegistry: {
@@ -54,5 +103,10 @@ declare module "obsidian" {
 declare global {
     interface Window {
         datacore?: DatacoreApi;
+        app: App;
+        CodeMirror: {
+            defineMode: (mode: string, conf: (config: any) => any) => unknown;
+            [key: string]: any;
+        };
     }
 }

--- a/src/typings/select.d.ts
+++ b/src/typings/select.d.ts
@@ -4,6 +4,7 @@ declare module "react-select" {
 		import { StateManagerAdditionalProps } from "react-select/dist/declarations/src/useStateManager";
 		import { Props } from "react-select/dist/declarations/src/Select";
 		import Select from "react-select/dist/declarations/src/Select";
+		export * from "react-select/dist/declarations/src/types";
 		declare type StateManagedPropKeys = 'inputValue' | 'menuIsOpen' | 'onChange' | 'onInputChange' | 'onMenuClose' | 'onMenuOpen' | 'value';
 		declare type PublicBaseSelectProps<Option, IsMulti extends boolean, Group extends GroupBase<Option>> = JSX.LibraryManagedAttributes<typeof Select, Props<Option, IsMulti, Group>>;
 		declare type SelectPropsWithOptionalStateManagedProps<Option, IsMulti extends boolean, Group extends GroupBase<Option>> = Omit<PublicBaseSelectProps<Option, IsMulti, Group>, StateManagedPropKeys> & Partial<PublicBaseSelectProps<Option, IsMulti, Group>>;

--- a/src/ui/hooks.tsx
+++ b/src/ui/hooks.tsx
@@ -218,6 +218,7 @@ export function useAsElement(element: ReactNode | Literal): ReactNode {
  * a simple hook that leverages `useEffect` and `useState` to
  * return some async data and its fulfillment status.
  *
+ * @group Hooks
  * @param loader a parameterless function that returns a promise
  * @param deps optional deps to pass to useEffect
  * @returns a tuple containing the resolved promise's value
@@ -235,6 +236,6 @@ export function useAsync<T>(loader: () => Promise<T>, deps: any[] = []): [T, boo
             .catch(() => {
                 setDone(true);
             });
-    }, [...deps, setValue, setDone]);
+    }, [...deps, setValue, setDone, loader]);
     return [value!, done];
 }

--- a/src/ui/hooks.tsx
+++ b/src/ui/hooks.tsx
@@ -214,3 +214,27 @@ export function useAsElement(element: ReactNode | Literal): ReactNode {
         }
     }, [element]);
 }
+/**
+ * a simple hook that leverages `useEffect` and `useState` to
+ * return some async data and its fulfillment status.
+ *
+ * @param loader a parameterless function that returns a promise
+ * @param deps optional deps to pass to useEffect
+ * @returns a tuple containing the resolved promise's value
+ * and a boolean indicating whether the promise has resolved.
+ */
+export function useAsync<T>(loader: () => Promise<T>, deps: any[] = []): [T, boolean] {
+    const [value, setValue] = useState<T | null>(null);
+    const [done, setDone] = useState<boolean>(false);
+    useEffect(() => {
+        loader()
+            .then((a) => {
+                setValue(a);
+                setDone(true);
+            })
+            .catch(() => {
+                setDone(true);
+            });
+    }, [...deps, setValue, setDone]);
+    return [value!, done];
+}

--- a/src/ui/view-page.css
+++ b/src/ui/view-page.css
@@ -1,0 +1,24 @@
+.dc-cm-editor .cm-gutters {
+    flex: 0 0 auto;
+    background-color: transparent;
+    color: var(--text-faint) !important;
+    border-right: none !important;
+    margin-inline-end: var(--file-folding-offset);
+    font-size: var(--font-ui-smaller);
+    z-index: 1;
+    font-variant: tabular-nums;
+}
+.cm-typeName {
+    color: var(--headers);
+}
+.dc-cm-editor {
+    padding: 1em;
+    border-radius: 0.5em;
+    border: 1px solid var(--h5-color);
+}
+.cm-tooltip.cm-tooltip-autocomplete {
+    background: var(--embed-bg);
+}
+.dc-cm-editor img.cm-widgetBuffer[aria-hidden="true"] {
+    display: none;
+}

--- a/src/ui/view-page.tsx
+++ b/src/ui/view-page.tsx
@@ -9,7 +9,7 @@ import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "p
 import { Textbox, VanillaSelect } from "api/ui/basics";
 import { useIndexUpdates } from "./hooks";
 import { DATACORE_CONTEXT, ErrorMessage } from "./markdown";
-import Select from "react-select";
+import {default as Select} from "react-select";
 import "./view-page.css";
 import { history, defaultKeymap, historyKeymap, indentWithTab } from "@codemirror/commands";
 import { foldGutter, indentOnInput, syntaxHighlighting, bracketMatching, foldKeymap } from "@codemirror/language";
@@ -343,7 +343,7 @@ function CurrentFileSelector({
 
     return (
         <Select
-            options={options}
+						options={options}
             classNamePrefix="datacore-selectable"
             defaultValue={defaultOption}	
             onChange={(nv, _am) => onChange(nv?.value)}

--- a/src/ui/view-page.tsx
+++ b/src/ui/view-page.tsx
@@ -345,7 +345,7 @@ function CurrentFileSelector({
         <Select
             options={options}
             classNamePrefix="datacore-selectable"
-            defaultValue={defaultOption}
+            defaultValue={defaultOption}	
             onChange={(nv, _am) => onChange(nv?.value)}
             unstyled
             menuPortalTarget={document.body}

--- a/src/ui/view-page.tsx
+++ b/src/ui/view-page.tsx
@@ -1,0 +1,534 @@
+import { debounce, ItemView, MarkdownRenderChild, Menu, Scope, ViewStateResult, WorkspaceLeaf } from "obsidian";
+import { ScriptLanguage } from "utils/javascript";
+import { DatacoreJSRenderer, ReactRenderer } from "./javascript";
+import { DatacoreLocalApi } from "api/local-api";
+import { DatacoreApi } from "api/api";
+import { createContext } from "preact";
+import { Group, Stack } from "api/ui/layout";
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "preact/hooks";
+import { Textbox, VanillaSelect } from "api/ui/basics";
+import { useIndexUpdates } from "./hooks";
+import { DATACORE_CONTEXT, ErrorMessage } from "./markdown";
+import Select from "react-select";
+import "./view-page.css";
+import { history, defaultKeymap, historyKeymap, indentWithTab } from "@codemirror/commands";
+import { foldGutter, indentOnInput, syntaxHighlighting, bracketMatching, foldKeymap } from "@codemirror/language";
+import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
+import { closeBrackets, closeBracketsKeymap, completionKeymap } from "@codemirror/autocomplete";
+import { lintKeymap } from "@codemirror/lint";
+import {
+    crosshairCursor,
+    drawSelection,
+    dropCursor,
+    EditorView,
+    highlightSpecialChars,
+    keymap,
+    lineNumbers,
+    rectangularSelection,
+    ViewPlugin,
+    ViewUpdate,
+} from "@codemirror/view";
+import { tagHighlighter, tags } from "@lezer/highlight";
+import { javascript } from "@codemirror/lang-javascript";
+import { vim } from "@replit/codemirror-vim";
+import { Compartment, EditorState } from "@codemirror/state";
+
+/** Key for datacore JS query views. */
+export const VIEW_TYPE_DATACOREJS = "datacorejs-view";
+
+/** Stores the current Obsidian view object, so it can be manipulated from react. */
+const CUSTOM_VIEW_CONTEXT = createContext<DatacoreQueryView>(undefined!);
+
+const EDITOR_HL = syntaxHighlighting(
+    tagHighlighter([
+        {
+            tag: tags.link,
+            class: "cm-link",
+        },
+        {
+            tag: tags.heading,
+            class: "cm-heading",
+        },
+        {
+            tag: tags.emphasis,
+            class: "cm-emphasis",
+        },
+        {
+            tag: tags.strong,
+            class: "cm-strong",
+        },
+        {
+            tag: tags.keyword,
+            class: "cm-keyword",
+        },
+        {
+            tag: tags.atom,
+            class: "cm-atom",
+        },
+        {
+            tag: tags.bool,
+            class: "cm-bool",
+        },
+        {
+            tag: tags.url,
+            class: "cm-url",
+        },
+        {
+            tag: tags.labelName,
+            class: "cm-labelName",
+        },
+        {
+            tag: tags.inserted,
+            class: "cm-inserted",
+        },
+        {
+            tag: tags.deleted,
+            class: "cm-deleted",
+        },
+        {
+            tag: tags.literal,
+            class: "cm-literal",
+        },
+        {
+            tag: tags.string,
+            class: "cm-string",
+        },
+        {
+            tag: tags.number,
+            class: "cm-number",
+        },
+        {
+            tag: [tags.regexp, tags.escape, tags.special(tags.string)],
+            class: "cm-string2",
+        },
+        {
+            tag: tags.variableName,
+            class: "cm-variableName",
+        },
+        {
+            tag: tags.local(tags.variableName),
+            class: "cm-variableName cm-local",
+        },
+        {
+            tag: tags.definition(tags.variableName),
+            class: "cm-variableName cm-definition",
+        },
+        {
+            tag: tags.special(tags.variableName),
+            class: "cm-variableName2",
+        },
+        {
+            tag: tags.definition(tags.propertyName),
+            class: "cm-propertyName cm-definition",
+        },
+        {
+            tag: tags.typeName,
+            class: "cm-typeName",
+        },
+        {
+            tag: tags.namespace,
+            class: "cm-namespace",
+        },
+        {
+            tag: tags.className,
+            class: "cm-className",
+        },
+        {
+            tag: tags.macroName,
+            class: "cm-macroName",
+        },
+        {
+            tag: tags.propertyName,
+            class: "cm-propertyName",
+        },
+        {
+            tag: tags.operator,
+            class: "cm-operator",
+        },
+        {
+            tag: tags.comment,
+            class: "cm-comment",
+        },
+        {
+            tag: tags.meta,
+            class: "cm-meta",
+        },
+        {
+            tag: tags.invalid,
+            class: "cm-invalid",
+        },
+        {
+            tag: tags.punctuation,
+            class: "cm-punctuation",
+        },
+    ])
+);
+const LANG_COMPARTMENT = new Compartment();
+const EDITOR_EXTS = [
+    lineNumbers(),
+    highlightSpecialChars(),
+    history(),
+    foldGutter(),
+    drawSelection(),
+    dropCursor(),
+    EditorState.allowMultipleSelections.of(true),
+    indentOnInput(),
+    bracketMatching(),
+    closeBrackets(),
+    rectangularSelection(),
+    crosshairCursor(),
+    highlightSelectionMatches(),
+    keymap.of([
+        indentWithTab,
+        ...closeBracketsKeymap,
+        ...defaultKeymap,
+        ...searchKeymap,
+        ...historyKeymap,
+        ...foldKeymap,
+        ...completionKeymap,
+        ...lintKeymap,
+    ]),
+    EditorView.baseTheme({
+        ".cm-cursor": {
+            borderLeftColor: "var(--text)",
+        },
+        ".cm-tooltip": {
+            backgroundColor: "var(--bg)",
+        },
+        "&:not(.cm-focused) .cm-fat-cursor": {
+            outline: "solid 1px var(--accent) !important",
+            background: "none",
+        },
+        "&.cm-focused .cm-fat-cursor": {
+            background: "var(--accent) !important",
+        },
+    }),
+];
+/** Provides a minimal editor with syntax highlighting */
+function CodeMirrorEditor({
+    state: { script, sourceType: lang },
+    setState,
+}: {
+    lang?: ScriptLanguage;
+    state: DatacoreViewState;
+    setState: (state: Partial<DatacoreViewState>) => void;
+}) {
+    const editorRef = useRef<HTMLDivElement>(null);
+    const viewRef = useRef<EditorView>(null);
+    const viewContext = useContext(CUSTOM_VIEW_CONTEXT);
+    useEffect(() => {
+        if (editorRef.current && !viewRef.current) {
+            viewRef.current = new EditorView({
+                parent: editorRef.current,
+                extensions: [viewContext.app.vault.getConfig("vimMode") && vim()].filter(Boolean).concat(
+                    ...EDITOR_EXTS.concat(
+                        ...[
+                            LANG_COMPARTMENT.of(javascript()),
+                            ViewPlugin.fromClass(
+                                class {
+                                    constructor(public view: EditorView) {}
+                                    update(update: ViewUpdate) {
+                                        if (update.docChanged) {
+                                            setState({ script: this.view.state.sliceDoc() || "" });
+                                        }
+                                    }
+                                }
+                            ),
+                            EDITOR_HL,
+                            viewContext.app.vault.getConfig("vimMode") && vim(),
+                            ...(viewContext.app.plugins.plugins["datacore-addon-autocomplete"]?.extensions || []),
+                        ].filter((a) => !!a)
+                    )
+                ),
+                doc: script || "",
+            });
+        }
+    }, [editorRef.current]);
+    useEffect(() => {
+        if (viewRef.current)
+            viewRef.current.dispatch({
+                effects: LANG_COMPARTMENT.reconfigure(
+                    javascript({ jsx: lang?.endsWith("x"), typescript: lang?.startsWith("ts") })
+                ),
+            });
+    }, [lang]);
+
+    return <div className="dc-cm-editor" ref={editorRef}></div>;
+}
+
+/** Provides options for configuring a datacore view pane. */
+function DatacoreViewSettings() {
+    const view = useContext(CUSTOM_VIEW_CONTEXT) as DatacoreQueryView;
+    const setViewState = useMemo(
+        () => debounce((state: Partial<DatacoreViewState>) => view.setState(state, { history: false }), 500),
+        [view]
+    );
+
+    const [localState, setLocalState] = useState(view.getState());
+    const setState = useCallback(
+        (state: Partial<DatacoreViewState>) => {
+            const finalState = { ...localState, ...state };
+            // Not debounced.
+            setLocalState(finalState);
+
+            // Debounced.
+            setViewState(finalState);
+        },
+        [localState, setLocalState, view]
+    );
+
+    return (
+        <Stack align="stretch">
+            <button className="clickable-icon" style="align-self: start" onClick={() => view.view("script")}>
+                {BACK_BUTTON}
+            </button>
+            <Group justify="space-between" align="center">
+                <h6>View Title</h6>
+                <Textbox
+                    defaultValue={view.getState().title}
+                    onChange={(e) => setState({ title: e.currentTarget.value as string })}
+                />
+            </Group>
+            <Group justify="space-between" align="center">
+                <h6>View Type</h6>
+                <VanillaSelect
+                    defaultValue={view.getState().sourceType}
+                    options={LANGUAGE_OPTIONS}
+                    value={localState.sourceType}
+                    onValueChange={(s) => setState({ sourceType: s as ScriptLanguage })}
+                />
+            </Group>
+            <Group justify="space-between" align="center">
+                <h6>Script/View source</h6>
+                <div style={{ minWidth: "75%", fontFamily: "monospace" }}>
+                    <CodeMirrorEditor state={localState} setState={setState} lang={localState.sourceType ?? "js"} />
+                </div>
+            </Group>
+            <Group justify="space-between" align="center">
+                <Stack>
+                    <h6>Current File</h6>
+                    <small>The path returned by functions like `useCurrentPath` in this view</small>
+                </Stack>
+                <div style={{ minWidth: "50%" }}>
+                    <CurrentFileSelector
+                        defaultValue={localState.currentFile}
+                        onChange={(v) => setState({ currentFile: v })}
+                    />
+                </div>
+            </Group>
+        </Stack>
+    );
+}
+
+/** React component for asynchronously showing the active set of current files to select one from. */
+function CurrentFileSelector({
+    defaultValue,
+    onChange,
+}: {
+    defaultValue?: string;
+    onChange: (value: string | undefined) => void;
+}) {
+    const core = useContext(DATACORE_CONTEXT);
+    const revision = useIndexUpdates(core, { debounce: 2000 });
+    const defaultOption = !defaultValue
+        ? { label: "No file", value: "" }
+        : { label: defaultValue!, value: defaultValue! };
+    // Cached list of relevant files, which is only recomputed on vault changes.
+    const options = useMemo(() => {
+        return core.vault
+            .getMarkdownFiles()
+            .map((f) => ({ label: f.path, value: f.path }))
+            .concat(defaultOption);
+    }, [revision]);
+
+    return (
+        <Select
+            options={options}
+            classNamePrefix="datacore-selectable"
+            defaultValue={defaultOption}
+            onChange={(nv, _am) => onChange(nv?.value)}
+            unstyled
+            menuPortalTarget={document.body}
+            tabIndex={-1}
+            styles={{
+                container(base, _props) {
+                    return { ...base, minWidth: "100%" };
+                },
+                menu(base, _props) {
+                    return { ...base, minWidth: "100%" };
+                },
+            }}
+            classNames={{
+                input: (props: any) => "prompt-input",
+                valueContainer: (props: any) => "suggestion-item value-container",
+                container: (props: any) => "suggestion-container",
+                menu: (props: any) => "suggestion-content suggestion-container",
+                option: (props: any) => `suggestion-item${props.isSelected ? " is-selected" : ""}`,
+            }}
+        />
+    );
+}
+
+/** Selectable options for picking which language to execute the script in. */
+const LANGUAGE_OPTIONS: { label: string; value: ScriptLanguage }[] = [
+    { label: "Javascript", value: "js" },
+    { label: "Typescript", value: "ts" },
+    { label: "Javascript (JSX)", value: "jsx" },
+    { label: "Typescript JSX", value: "tsx" },
+];
+
+/** SVG back button shown to exit the settings view. */
+const BACK_BUTTON = (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="svg-icon lucide-arrow-left"
+    >
+        <path d="m12 19-7-7 7-7"></path>
+        <path d="M19 12H5"></path>
+    </svg>
+);
+
+/** State for the datacore view page. */
+export interface DatacoreViewState {
+    /** Custom title for the view pane. */
+    title?: string;
+    /** Language that the script will be executed in. */
+    sourceType?: ScriptLanguage;
+    /** If defined, the file the view will be relative to. */
+    currentFile?: string;
+    /** Contents of the script. */
+    script?: string;
+    /** The current view; defaults to 'settings' for initialization. */
+    view?: "settings" | "script";
+}
+
+export class DatacoreQueryView extends ItemView {
+    /** Internal current state of the view; can be modified by setState. */
+    public internalState: DatacoreViewState = {
+        title: "New view",
+        script: "",
+        sourceType: "js",
+        view: "settings",
+    };
+
+    /** The current active view - either the settings view */
+    private activeView: MarkdownRenderChild;
+    private activeViewType: string;
+
+    constructor(leaf: WorkspaceLeaf, public api: DatacoreApi) {
+        super(leaf);
+        this.rerender();
+    }
+
+    /** Should always be VIEW_TYPE_DATACOREJS. */
+    getViewType(): string {
+        return VIEW_TYPE_DATACOREJS;
+    }
+
+    /** Text shown in the title window. */
+    getDisplayText(): string {
+        return `${this.internalState.title} (DatacoreJS)`;
+    }
+
+    public async onload() {
+        this.contentEl.addClass("markdown-rendered");
+        this.registerDomEvent(this.containerEl, "keydown", (k) => {
+            if (k.charCode == 27) {
+                k.preventDefault();
+                k.stopPropagation();
+            }
+        });
+        this.scope = new Scope(this.app.scope);
+        this.scope?.register(null, "Escape", (ev) => {});
+        this.rerender();
+    }
+
+    public onunload(): void {
+        if (this.activeView) this.removeChild(this.activeView);
+    }
+
+    /** Synchronizes the screen state to properly reflect the current internal state. */
+    rerender(): void {
+        this.leaf.tabHeaderInnerTitleEl.textContent = this.titleEl.textContent = this.getDisplayText();
+        if (this.activeViewType == this.internalState.view) return;
+
+        if (this.activeView) this.removeChild(this.activeView);
+        if (this.internalState.view === "settings") {
+            this.activeViewType = "settings";
+            this.activeView = new ReactRenderer(
+                this.app,
+                this.api.core,
+                this.contentEl,
+                this.internalState.currentFile || "",
+                (
+                    <CUSTOM_VIEW_CONTEXT.Provider value={this}>
+                        <DatacoreViewSettings />
+                    </CUSTOM_VIEW_CONTEXT.Provider>
+                )
+            );
+        } else {
+            // If a script, try to execute it; otherwise, show a reasonable error message.
+            this.activeViewType = "script";
+            if (this.internalState.script) {
+                this.activeView = new DatacoreJSRenderer(
+                    new DatacoreLocalApi(this.api, this.internalState.currentFile || ""),
+                    this.contentEl,
+                    this.internalState.currentFile || "",
+                    this.internalState.script || "",
+                    this.internalState.sourceType || "js"
+                );
+            } else {
+                this.activeView = new ReactRenderer(
+                    this.app,
+                    this.api.core,
+                    this.contentEl,
+                    this.internalState.currentFile || "",
+                    (
+                        <CUSTOM_VIEW_CONTEXT.Provider value={this}>
+                            <ErrorMessage message="No script defined for this view." />
+                        </CUSTOM_VIEW_CONTEXT.Provider>
+                    )
+                );
+            }
+        }
+
+        this.addChild(this.activeView);
+    }
+
+    public getState() {
+        return this.internalState;
+    }
+
+    /** Update the state of this view with new metadata. Generally controlled by the settings pane. */
+    public async setState(state: DatacoreViewState, _result: ViewStateResult): Promise<void> {
+        this.internalState = state;
+        this.rerender();
+    }
+
+    /** Swap the active view. */
+    public view(mode: "settings" | "script"): void {
+        this.internalState.view = mode;
+        this.rerender();
+    }
+
+    public async onOpen(): Promise<void> {}
+
+    /** Handle for right click menus. */
+    public onPaneMenu(menu: Menu, source: "more-options" | "tab-header" | string): void {
+        if (source === "more-options") {
+            menu.addItem((it) => {
+                it.setIcon("settings");
+                it.setTitle("Configure View");
+                it.onClick((e) => this.view("settings"));
+            });
+        }
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,6 +286,16 @@
     "@codemirror/view" "^6.17.0"
     "@lezer/common" "^1.0.0"
 
+"@codemirror/commands@^6.8.1":
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.8.1.tgz#639f5559d2f33f2582a2429c58cb0c1b925c7a30"
+  integrity sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.4.0"
+    "@codemirror/view" "^6.27.0"
+    "@lezer/common" "^1.1.0"
+
 "@codemirror/lang-javascript@^6.2.3":
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/@codemirror/lang-javascript/-/lang-javascript-6.2.3.tgz#d705c359dc816afcd3bcdf120a559f83d31d4cda"
@@ -336,6 +346,15 @@
   dependencies:
     "@marijn/find-cluster-break" "^1.0.0"
 
+"@codemirror/view@^6.0.0", "@codemirror/view@^6.17.0", "@codemirror/view@^6.27.0", "@codemirror/view@^6.35.0":
+  version "6.36.7"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.36.7.tgz#f3711d3fea457a3eec1c09a76b8a132f98df17b1"
+  integrity sha512-kCWGW/chWGPgZqfZ36Um9Iz0X2IVpmCjg1P/qY6B6a2ecXtWRRAigmpJ6YgUQ5lTWXMyyVdfmpzhLZmsZQMbtg==
+  dependencies:
+    "@codemirror/state" "^6.5.0"
+    style-mod "^4.1.0"
+    w3c-keyname "^2.2.4"
+
 "@codemirror/view@^6.0.1", "@codemirror/view@^6.23.0":
   version "6.38.0"
   resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.38.0.tgz#4486062b791a4247793e0953e05ae71a9e172217"
@@ -343,15 +362,6 @@
   dependencies:
     "@codemirror/state" "^6.5.0"
     crelt "^1.0.6"
-    style-mod "^4.1.0"
-    w3c-keyname "^2.2.4"
-
-"@codemirror/view@^6.17.0", "@codemirror/view@^6.35.0":
-  version "6.36.7"
-  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.36.7.tgz#f3711d3fea457a3eec1c09a76b8a132f98df17b1"
-  integrity sha512-kCWGW/chWGPgZqfZ36Um9Iz0X2IVpmCjg1P/qY6B6a2ecXtWRRAigmpJ6YgUQ5lTWXMyyVdfmpzhLZmsZQMbtg==
-  dependencies:
-    "@codemirror/state" "^6.5.0"
     style-mod "^4.1.0"
     w3c-keyname "^2.2.4"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -346,7 +346,7 @@
   dependencies:
     "@marijn/find-cluster-break" "^1.0.0"
 
-"@codemirror/view@^6.0.0", "@codemirror/view@^6.17.0", "@codemirror/view@^6.27.0", "@codemirror/view@^6.35.0":
+"@codemirror/view@^6.0.0", "@codemirror/view@^6.17.0", "@codemirror/view@^6.27.0", "@codemirror/view@^6.35.0", "@codemirror/view@^6.36.7":
   version "6.36.7"
   resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.36.7.tgz#f3711d3fea457a3eec1c09a76b8a132f98df17b1"
   integrity sha512-kCWGW/chWGPgZqfZ36Um9Iz0X2IVpmCjg1P/qY6B6a2ecXtWRRAigmpJ6YgUQ5lTWXMyyVdfmpzhLZmsZQMbtg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -276,6 +276,41 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@codemirror/autocomplete@^6.0.0", "@codemirror/autocomplete@^6.18.6":
+  version "6.18.6"
+  resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-6.18.6.tgz#de26e864a1ec8192a1b241eb86addbb612964ddb"
+  integrity sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+
+"@codemirror/lang-javascript@^6.2.3":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-javascript/-/lang-javascript-6.2.3.tgz#d705c359dc816afcd3bcdf120a559f83d31d4cda"
+  integrity sha512-8PR3vIWg7pSu7ur8A07pGiYHgy3hHj+mRYRCSG8q+mPIrl0F02rgpGv+DsQTHRTc30rydOsf5PZ7yjKFg2Ackw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.6.0"
+    "@codemirror/lint" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/javascript" "^1.0.0"
+
+"@codemirror/language@^6.0.0", "@codemirror/language@^6.6.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.11.0.tgz#5ae90972601497f4575f30811519d720bf7232c9"
+  integrity sha512-A7+f++LodNNc1wGgoRDTt78cOwWm9KVezApgjOMp1W4hM0898nsqBXwF+sbePE7ZRcjN7Sa1Z5m2oN27XkmEjQ==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.23.0"
+    "@lezer/common" "^1.1.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+    style-mod "^4.0.0"
+
 "@codemirror/language@https://github.com/lishid/cm-language":
   version "6.11.2"
   resolved "https://github.com/lishid/cm-language#a9c3c7efe17dd1d24395ee2a179fe12dd6ed1e76"
@@ -294,6 +329,13 @@
   dependencies:
     "@marijn/find-cluster-break" "^1.0.0"
 
+"@codemirror/state@^6.5.0":
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.5.2.tgz#8eca3a64212a83367dc85475b7d78d5c9b7076c6"
+  integrity sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==
+  dependencies:
+    "@marijn/find-cluster-break" "^1.0.0"
+
 "@codemirror/view@^6.0.1", "@codemirror/view@^6.23.0":
   version "6.38.0"
   resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.38.0.tgz#4486062b791a4247793e0953e05ae71a9e172217"
@@ -301,6 +343,15 @@
   dependencies:
     "@codemirror/state" "^6.5.0"
     crelt "^1.0.6"
+    style-mod "^4.1.0"
+    w3c-keyname "^2.2.4"
+
+"@codemirror/view@^6.17.0", "@codemirror/view@^6.35.0":
+  version "6.36.7"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.36.7.tgz#f3711d3fea457a3eec1c09a76b8a132f98df17b1"
+  integrity sha512-kCWGW/chWGPgZqfZ36Um9Iz0X2IVpmCjg1P/qY6B6a2ecXtWRRAigmpJ6YgUQ5lTWXMyyVdfmpzhLZmsZQMbtg==
+  dependencies:
+    "@codemirror/state" "^6.5.0"
     style-mod "^4.1.0"
     w3c-keyname "^2.2.4"
 
@@ -796,12 +847,33 @@
   resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.2.3.tgz#138fcddab157d83da557554851017c6c1e5667fd"
   integrity sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==
 
+"@lezer/common@^1.2.0":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.2.3.tgz#138fcddab157d83da557554851017c6c1e5667fd"
+  integrity sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==
+
 "@lezer/highlight@^1.0.0":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@lezer/highlight/-/highlight-1.2.1.tgz#596fa8f9aeb58a608be0a563e960c373cbf23f8b"
   integrity sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==
   dependencies:
     "@lezer/common" "^1.0.0"
+
+"@lezer/highlight@^1.1.3":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@lezer/highlight/-/highlight-1.2.1.tgz#596fa8f9aeb58a608be0a563e960c373cbf23f8b"
+  integrity sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+
+"@lezer/javascript@^1.0.0":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@lezer/javascript/-/javascript-1.5.1.tgz#2a424a6ec29f1d4ef3c34cbccc5447e373618ad8"
+  integrity sha512-ATOImjeVJuvgm3JQ/bpo2Tmv55HSScE2MTPnKRMRIPx2cLhHGyX2VnqpHhtIV1tVzIjZDbcWQm+NCTF40ggZVw==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.1.3"
+    "@lezer/lr" "^1.3.0"
 
 "@lezer/lr@^1.0.0":
   version "1.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -346,7 +346,7 @@
   dependencies:
     "@marijn/find-cluster-break" "^1.0.0"
 
-"@codemirror/view@^6.0.0", "@codemirror/view@^6.17.0", "@codemirror/view@^6.27.0", "@codemirror/view@^6.35.0", "@codemirror/view@^6.36.7":
+"@codemirror/view@^6.0.0", "@codemirror/view@^6.17.0", "@codemirror/view@^6.23.0", "@codemirror/view@^6.27.0", "@codemirror/view@^6.35.0", "@codemirror/view@^6.36.7":
   version "6.36.7"
   resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.36.7.tgz#f3711d3fea457a3eec1c09a76b8a132f98df17b1"
   integrity sha512-kCWGW/chWGPgZqfZ36Um9Iz0X2IVpmCjg1P/qY6B6a2ecXtWRRAigmpJ6YgUQ5lTWXMyyVdfmpzhLZmsZQMbtg==
@@ -2036,6 +2036,11 @@ glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+gopd@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
 gopd@^1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -863,6 +863,11 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@replit/codemirror-vim@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@replit/codemirror-vim/-/codemirror-vim-6.3.0.tgz#1bcde09f25bcb1c4f96d2cd50ea07f9f71fc9ec4"
+  integrity sha512-aTx931ULAMuJx6xLf7KQDOL7CxD+Sa05FktTDrtLaSy53uj01ll3Zf17JdKsriER248oS55GBzg0CfCTjEneAQ==
+
 "@rushstack/node-core-library@5.13.1":
   version "5.13.1"
   resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-5.13.1.tgz#e56b915ecb08b5a92711acac6b233417353a32dc"


### PR DESCRIPTION
to quote the roadmap:

> Special page types which are just Datacore views and which can be put into the side bar or as regular pages.

each view page has its own state consisting of the following properties:

- `sourceType`: the type of script this view will contain (ex: `ts`, `js`, `jsx`, `tsx`...)
- `script`: the actual source code for the script
- `title`: the title, as displayed in the tab/view header
- `currentFile`: the configurable path to the current file, so that functions and hooks such as `useCurrentPath` don't choke

all of these are configurable via the view's settings page, which can be accessed via going into the three-dot menu and clicking "View configuration".

a command to create a view page has also been added to the command palette for ease of use.

as always, let me know if i should add or change anything! :)