### PR TITLE
Fixes VanillaSelect requiring two renders to update

### DIFF
--- a/src/api/ui/basics.tsx
+++ b/src/api/ui/basics.tsx
@@ -169,11 +169,7 @@ export function VanillaSelect(
     } & React.ComponentProps<"select">
 ) {
     const { className, options = [], value, defaultValue, onValueChange, ...forwardingProps } = props;
-    const [selectedValue, setSelectedValue] = React.useState(value ?? defaultValue ?? "");
-
-    React.useEffect(() => {
-        if (typeof value === "string") setSelectedValue(value);
-    }, [value]);
+    const [selectedValue, setSelectedValue] = useControlledState(defaultValue ?? "", value, onValueChange);
 
     return (
         <select
@@ -181,7 +177,6 @@ export function VanillaSelect(
             value={selectedValue}
             onChange={(e) => {
                 setSelectedValue(e.currentTarget.value);
-                onValueChange && onValueChange(e.currentTarget.value);
             }}
             {...forwardingProps}
         >


### PR DESCRIPTION
I was having issues with the VanillaSelect not updating its state when something update the metadatacache

I've swapped it to use useControlledState like all the other components. Fixed it for me.