### PR TITLE
make cleantext work with list items with id

### DIFF
--- a/docs/docs/data/blocks.md
+++ b/docs/docs/data/blocks.md
@@ -94,7 +94,7 @@ Datacore tracks all list items and tasks in your vault; they are available as th
 | `$parentLine` | The line number of the parent item of this list item. For top-level list items, this will be a negative number equal to the line number of the start of the list block. | `14` or `-7` |
 | `$symbol` | The list item symbol used for this list item. | `-` or `*` or `+` or `1.` |
 | `$text` | The full text of the list item, not including any list markup. | `TODO: Do something. [key:: value]` |
-| `$cleantext` | "Cleaned up" version of `text` which has indentation and inline fields removed. | `TODO: Do something.` |
+| `$cleantext` | "Cleaned up" version of `text` which has indentation, inline fields, and id removed. | `TODO: Do something.` |
 | `$elements` | A list of all sub items under this list item. | See this type. |
 
 Like most other types, inline field values can be fetched from list items using [field syntax](fields).

--- a/src/index/types/markdown.ts
+++ b/src/index/types/markdown.ts
@@ -615,14 +615,18 @@ export class MarkdownListItem implements Indexable, Linkbearing, Taggable, Field
         return this.$position.end - this.$position.start + 1;
     }
 
-    /** Cleaned text that is garaunteed to be non-null and has indenation and inline fields removed. */
+    /** Cleaned text that is guaranteed to be non-null and has indentation, inline fields, and id removed. */
     get $cleantext() {
         if (!this.$text) return "";
 
         return (
             this.$text
-                // Eliminate [key:: value] annotations.
-                .replace(/(.*?)([\[\(][^:(\[]+::\s*.*?[\]\)]\s*)$/gm, "$1")
+                // Capture three groups:
+                // 1) all characters up until group 2 or 3 is encountered
+                // 2) zero or more inline fields
+                // 3) zero or one id,
+                // and replace it with just group 1
+                .replace(/(.*?)([\[\(][^:(\[]+::\s*.*?[\]\)]\s*)*(\^.+){0,1}$/gm, "$1")
                 // Trim whitespace.
                 .trim()
         );

--- a/src/test/index/types/markdown.test.ts
+++ b/src/test/index/types/markdown.test.ts
@@ -1,0 +1,28 @@
+import { MarkdownTaskItem } from "index/types/markdown";
+
+describe("cleantext", () => {
+    const cleanText = "nice and clean";
+
+    test("allready clean", () => expect(new MarkdownTaskItem({ $text: cleanText }).$cleantext).toBe(cleanText));
+    test("trailing spaces", () => expect(new MarkdownTaskItem({ $text: cleanText + "  " }).$cleantext).toBe(cleanText));
+    test("leading spaces", () => expect(new MarkdownTaskItem({ $text: "  " + cleanText }).$cleantext).toBe(cleanText));
+    test("with tab indent", () => expect(new MarkdownTaskItem({ $text: "\t" + cleanText }).$cleantext).toBe(cleanText));
+    test("with square bracket inline field", () =>
+        expect(new MarkdownTaskItem({ $text: cleanText + "[key:: value]" }).$cleantext).toBe(cleanText));
+    test("with round bracket inline field", () =>
+        expect(new MarkdownTaskItem({ $text: cleanText + "(key:: value)" }).$cleantext).toBe(cleanText));
+    test("with multiple inline fields", () =>
+        expect(new MarkdownTaskItem({ $text: cleanText + " (key:: value) [another:: one]" }).$cleantext).toBe(
+            cleanText
+        ));
+    test("with id", () => expect(new MarkdownTaskItem({ $text: cleanText + " ^id" }).$cleantext).toBe(cleanText));
+    test("with inline field and id", () =>
+        expect(new MarkdownTaskItem({ $text: cleanText + "[key:: value] ^id" }).$cleantext).toBe(cleanText));
+    test("all combined", () =>
+        expect(
+            new MarkdownTaskItem({ $text: "\t" + cleanText + "  [key:: value] (another :: one) ^some-id    " })
+                .$cleantext
+        ).toBe(cleanText));
+    test("just inline fields and id", () =>
+        expect(new MarkdownTaskItem({ $text: "[key:: value] ^id" }).$cleantext).toBe(""));
+});


### PR DESCRIPTION
# The problem
`$cleantext` is supposed to remove inline fields from the text of list and task items, but inline fields are not removed when the item has an id.

# Possible solutions
I see two possible approaches to solving this:
1. Make `$cleantext` remove the id as well as inline fields and indentation, and update the documentation accordingly.
2. Make `$cleantext` remove just inline fields and indentation, as stated in the documentation, and return the id with the text.

# This PR
I chose to implement solution number 1 because I see ids as technical details, and not as part of the content of a task or list item. 

As I've not contributed to this project before, please let me know if I should have approached this differently in any way. 
