### PR TITLE
Add support to specify the type returned by query functions

### DIFF
--- a/datacore.api.md
+++ b/datacore.api.md
@@ -149,6 +149,17 @@ export class Canvas implements Linkable, File_2, Linkbearing, Taggable, Indexabl
     static TYPES: string[];
 }
 
+// @public (undocumented)
+export namespace Canvas {
+    // Warning: (ae-forgotten-export) The symbol "TypedFieldbearing" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    export interface Typed<Fields extends {
+        [key in string]?: Literal;
+    }> extends Omit<Canvas, keyof TypedFieldbearing<Fields>>, TypedFieldbearing<Fields> {
+    }
+}
+
 // @public
 export type CanvasCard = CanvasTextCard | CanvasFileCard | CanvasWebCard;
 
@@ -216,6 +227,15 @@ export class CanvasTextCard extends BaseCanvasCard implements Linkbearing, Tagga
     json(): JsonCanvasTextCard;
     // (undocumented)
     static TYPES: string[];
+}
+
+// @public (undocumented)
+export namespace CanvasTextCard {
+    // (undocumented)
+    export interface Typed<Fields extends {
+        [key in string]?: Literal;
+    }> extends Omit<CanvasTextCard, keyof TypedFieldbearing<Fields>>, TypedFieldbearing<Fields> {
+    }
 }
 
 // @public (undocumented)
@@ -396,21 +416,21 @@ export class DatacoreApi {
     executeTs(source: string, container: HTMLElement, component: Component | MarkdownPostProcessorContext, sourcePath: string): MarkdownRenderChild;
     executeTsx(source: string, container: HTMLElement, component: Component | MarkdownPostProcessorContext, sourcePath: string): MarkdownRenderChild;
     fileLink(path: string): Link;
-    fullquery(query: string | IndexQuery): SearchResult<Indexable>;
+    fullquery<T extends Indexable = Indexable>(query: string | IndexQuery): SearchResult<T>;
     headerLink(path: string, header: string): Link;
     local(path: string): DatacoreLocalApi;
     get luxon(): typeof luxon_2;
-    page(path: string | Link): MarkdownPage | undefined;
+    page<T extends MarkdownPage = MarkdownPage>(path: string | Link): T | undefined;
     parseLink(linktext: string): Link;
     parseQuery(query: string | IndexQuery): IndexQuery;
     get preact(): typeof preact_2;
-    query(query: string | IndexQuery): Indexable[];
+    query<T extends Indexable = Indexable>(query: string | IndexQuery): T[];
     resolvePath(path: string | Link, sourcePath?: string): string;
     tryEvaluate(expression: string | Expression, variables?: Record<string, Literal>, sourcePath?: string): Result<Literal, string>;
-    tryFullQuery(query: string | IndexQuery): Result<SearchResult<Indexable>, string>;
+    tryFullQuery<T extends Indexable = Indexable>(query: string | IndexQuery): Result<SearchResult<T>, string>;
     tryParseLink(linktext: string): Result<Link, string>;
     tryParseQuery(query: string | IndexQuery): Result<IndexQuery, string>;
-    tryQuery(query: string | IndexQuery): Result<Indexable[], string>;
+    tryQuery<T extends Indexable = Indexable>(query: string | IndexQuery): Result<T[], string>;
 }
 
 // @public
@@ -431,12 +451,12 @@ export class DatacoreLocalApi {
     coerce: typeof Coerce;
     get core(): Datacore;
     createContext: typeof preact_2.createContext;
-    currentFile(): MarkdownPage;
+    currentFile<T extends MarkdownPage = MarkdownPage>(): T;
     currentPath(): string;
     embed: any;
     evaluate(expression: string | Expression, variables?: Record<string, Literal>, sourcePath?: string): Literal;
     fileLink(path: string): Link;
-    fullquery(query: string | IndexQuery): SearchResult<Indexable>;
+    fullquery<T extends Indexable = Indexable>(query: string | IndexQuery): SearchResult<T>;
     Group: typeof Group;
     headerLink(path: string, header: string): Link;
     Icon: typeof Icon;
@@ -454,7 +474,7 @@ export class DatacoreLocalApi {
     // (undocumented)
     path: string;
     get preact(): typeof preact_2;
-    query(query: string | IndexQuery): Indexable[];
+    query<T extends Indexable = Indexable>(query: string | IndexQuery): T[];
     require(path: string | Link): Promise<unknown>;
     resolvePath(path: string | Link, sourcePath?: string): string;
     // (undocumented)
@@ -467,35 +487,35 @@ export class DatacoreLocalApi {
     // (undocumented)
     Textbox: typeof Textbox;
     tryEvaluate(expression: string | Expression, variables?: Record<string, Literal>, sourcePath?: string): Result<Literal, string>;
-    tryFullQuery(query: string | IndexQuery): Result<SearchResult<Indexable>, string>;
+    tryFullQuery<T extends Indexable = Indexable>(query: string | IndexQuery): Result<SearchResult<T>, string>;
     tryParseLink(linktext: string): Result<Link, string>;
     tryParseQuery(query: string | IndexQuery): Result<IndexQuery, string>;
-    tryQuery(query: string | IndexQuery): Result<Indexable[], string>;
+    tryQuery<T extends Indexable = Indexable>(query: string | IndexQuery): Result<T[], string>;
     useArray<T, U>(input: T[] | DataArray<T>, process: (data: DataArray<T>) => DataArray<U>, deps?: unknown[]): U[];
     useCallback: typeof hooks.useCallback;
     useContext: typeof hooks.useContext;
-    useCurrentFile(settings?: {
+    useCurrentFile<T extends MarkdownPage = MarkdownPage>(settings?: {
         debounce?: number;
-    }): MarkdownPage;
+    }): T;
     useCurrentPath(settings?: {
         debounce?: number;
     }): string;
     useEffect: typeof hooks.useEffect;
-    useFile(path: string, settings?: {
+    useFile<T extends Indexable = Indexable>(path: string, settings?: {
         debounce?: number;
-    }): Indexable | undefined;
-    useFullQuery(query: string | IndexQuery, settings?: {
+    }): T | undefined;
+    useFullQuery<T extends Indexable = Indexable>(query: string | IndexQuery, settings?: {
         debounce?: number;
-    }): SearchResult<Indexable>;
+    }): SearchResult<T>;
     useIndexUpdates(settings?: {
         debounce?: number;
     }): number;
     // Warning: (ae-forgotten-export) The symbol "useInterning" needs to be exported by the entry point index.d.ts
     useInterning: typeof useInterning;
     useMemo: typeof hooks.useMemo;
-    useQuery(query: string | IndexQuery, settings?: {
+    useQuery<T extends Indexable = Indexable>(query: string | IndexQuery, settings?: {
         debounce?: number;
-    }): Indexable[];
+    }): T[];
     useReducer: typeof hooks.useReducer;
     useRef: typeof hooks.useRef;
     useState: typeof hooks.useState;
@@ -1133,6 +1153,17 @@ export class MarkdownBlock implements Indexable, Linkbearing, Taggable, Fieldbea
     value(key: string): Literal | undefined;
 }
 
+// @public (undocumented)
+export namespace MarkdownBlock {
+    // Warning: (ae-forgotten-export) The symbol "TypedValuebearing" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    export interface Typed<Fields extends {
+        [key in string]?: Literal;
+    }> extends Omit<MarkdownBlock, keyof TypedValuebearing<Fields>>, TypedValuebearing<Fields> {
+    }
+}
+
 // @public
 export class MarkdownCodeblock extends MarkdownBlock implements Indexable, Fieldbearing, Linkbearing {
     // (undocumented)
@@ -1164,6 +1195,15 @@ export class MarkdownCodeblock extends MarkdownBlock implements Indexable, Field
     value(key: string): Literal | undefined;
 }
 
+// @public (undocumented)
+export namespace MarkdownCodeblock {
+    // (undocumented)
+    export interface Typed<Fields extends {
+        [key in string]?: Literal;
+    }> extends Omit<MarkdownCodeblock, keyof TypedValuebearing<Fields>>, TypedValuebearing<Fields> {
+    }
+}
+
 // @public
 export class MarkdownDatablock extends MarkdownBlock implements Indexable, Fieldbearing, Linkbearing {
     // (undocumented)
@@ -1189,6 +1229,15 @@ export class MarkdownDatablock extends MarkdownBlock implements Indexable, Field
     value(key: string): Literal | undefined;
 }
 
+// @public (undocumented)
+export namespace MarkdownDatablock {
+    // (undocumented)
+    export interface Typed<Fields extends {
+        [key in string]?: Literal;
+    }> extends Omit<MarkdownDatablock, keyof TypedValuebearing<Fields>>, TypedValuebearing<Fields> {
+    }
+}
+
 // @public
 export class MarkdownListBlock extends MarkdownBlock implements Taggable, Linkbearing {
     $elements: MarkdownListItem[];
@@ -1205,6 +1254,15 @@ export class MarkdownListBlock extends MarkdownBlock implements Taggable, Linkbe
     json(): JsonMarkdownListBlock;
     // (undocumented)
     static TYPES: string[];
+}
+
+// @public (undocumented)
+export namespace MarkdownListBlock {
+    // (undocumented)
+    export interface Typed<Fields extends {
+        [key in string]?: Literal;
+    }> extends Omit<MarkdownListBlock, keyof TypedValuebearing<Fields>>, TypedValuebearing<Fields> {
+    }
 }
 
 // @public
@@ -1246,6 +1304,15 @@ export class MarkdownListItem implements Indexable, Linkbearing, Taggable, Field
     value(key: string): Literal | undefined;
 }
 
+// @public (undocumented)
+export namespace MarkdownListItem {
+    // (undocumented)
+    export interface Typed<Fields extends {
+        [key in string]?: Literal;
+    }> extends Omit<MarkdownListItem, keyof TypedValuebearing<Fields>>, TypedValuebearing<Fields> {
+    }
+}
+
 // @public
 export class MarkdownPage implements File_2, Linkbearing, Taggable, Indexable, Fieldbearing {
     $ctime: DateTime;
@@ -1282,6 +1349,15 @@ export class MarkdownPage implements File_2, Linkbearing, Taggable, Indexable, F
     value(key: string): Literal | undefined;
 }
 
+// @public (undocumented)
+export namespace MarkdownPage {
+    // (undocumented)
+    export interface Typed<Fields extends {
+        [key in string]?: Literal;
+    }> extends Omit<MarkdownPage, keyof TypedValuebearing<Fields>>, TypedValuebearing<Fields> {
+    }
+}
+
 // @public
 export class MarkdownSection implements Indexable, Taggable, Linkable, Linkbearing, Fieldbearing {
     $blocks: MarkdownBlock[];
@@ -1316,6 +1392,15 @@ export class MarkdownSection implements Indexable, Taggable, Linkable, Linkbeari
     value(key: string): Literal | undefined;
 }
 
+// @public (undocumented)
+export namespace MarkdownSection {
+    // (undocumented)
+    export interface Typed<Fields extends {
+        [key in string]?: Literal;
+    }> extends Omit<MarkdownSection, keyof TypedValuebearing<Fields>>, TypedValuebearing<Fields> {
+    }
+}
+
 // @public
 export class MarkdownTaskItem extends MarkdownListItem implements Indexable, Linkbearing, Taggable, Fieldbearing {
     get $completed(): boolean;
@@ -1333,6 +1418,15 @@ export class MarkdownTaskItem extends MarkdownListItem implements Indexable, Lin
     json(): JsonMarkdownListItem;
     // (undocumented)
     static TYPES: string[];
+}
+
+// @public (undocumented)
+export namespace MarkdownTaskItem {
+    // (undocumented)
+    export interface Typed<Fields extends {
+        [key in string]?: Literal;
+    }> extends Omit<MarkdownTaskItem, keyof TypedValuebearing<Fields>>, TypedValuebearing<Fields> {
+    }
 }
 
 // @public

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -57,6 +57,7 @@ export class DatacoreApi {
     /////////////////////////
 
     /** Load a markdown file by full path or link. */
+    public page<T extends MarkdownPage = MarkdownPage>(path: string | Link): T | undefined;
     public page(path: string | Link): MarkdownPage | undefined {
         const realPath = path instanceof Link ? path.path : path;
 
@@ -64,21 +65,25 @@ export class DatacoreApi {
     }
 
     /** Execute a textual or typed index query, returning all results. */
+    public query<T extends Indexable = Indexable>(query: string | IndexQuery): T[];
     public query(query: string | IndexQuery): Indexable[] {
         return this.tryQuery(query).orElseThrow();
     }
 
     /** Execute a textual or typed index query, returning all results. */
+    public tryQuery<T extends Indexable = Indexable>(query: string | IndexQuery): Result<T[], string>;
     public tryQuery(query: string | IndexQuery): Result<Indexable[], string> {
         return this.tryFullQuery(query).map((result) => result.results);
     }
 
     /** Execute a textual or typed index query, returning results plus performance metadata. */
+    public fullquery<T extends Indexable = Indexable>(query: string | IndexQuery): SearchResult<T>;
     public fullquery(query: string | IndexQuery): SearchResult<Indexable> {
         return this.tryFullQuery(query).orElseThrow();
     }
 
     /** Execute a textual or typed index query, returning results plus performance metadata. */
+    public tryFullQuery<T extends Indexable = Indexable>(query: string | IndexQuery): Result<SearchResult<T>, string>;
     public tryFullQuery(query: string | IndexQuery): Result<SearchResult<Indexable>, string> {
         const parsedQuery = typeof query === "string" ? QUERY.query.tryParse(query) : query;
         return this.core.datastore.search(parsedQuery);

--- a/src/api/local-api.tsx
+++ b/src/api/local-api.tsx
@@ -47,6 +47,7 @@ export class DatacoreLocalApi {
     }
 
     /** The full markdown file metadata for the current file. */
+    public currentFile<T extends MarkdownPage = MarkdownPage>(): T;
     public currentFile(): MarkdownPage {
         return this.api.page(this.path)!;
     }
@@ -167,21 +168,25 @@ export class DatacoreLocalApi {
     }
 
     /** Execute a textual or typed index query, returning all results. */
+    public query<T extends Indexable = Indexable>(query: string | IndexQuery): T[];
     public query(query: string | IndexQuery): Indexable[] {
         return this.api.query(query);
     }
 
     /** Execute a textual or typed index query, returning all results. */
+    public tryQuery<T extends Indexable = Indexable>(query: string | IndexQuery): Result<T[], string>;
     public tryQuery(query: string | IndexQuery): Result<Indexable[], string> {
         return this.api.tryQuery(query);
     }
 
     /** Execute a textual or typed index query, returning results plus performance metadata. */
+    public fullquery<T extends Indexable = Indexable>(query: string | IndexQuery): SearchResult<T>;
     public fullquery(query: string | IndexQuery): SearchResult<Indexable> {
         return this.api.fullquery(query);
     }
 
     /** Execute a textual or typed index query, returning results plus performance metadata. */
+    public tryFullQuery<T extends Indexable = Indexable>(query: string | IndexQuery): Result<SearchResult<T>, string>;
     public tryFullQuery(query: string | IndexQuery): Result<SearchResult<Indexable>, string> {
         return this.api.tryFullQuery(query);
     }
@@ -225,6 +230,7 @@ export class DatacoreLocalApi {
     }
 
     /** Use the file metadata for the current file. Automatically updates the view when the current file metadata changes. */
+    public useCurrentFile<T extends MarkdownPage = MarkdownPage>(settings?: { debounce?: number }): T;
     public useCurrentFile(settings?: { debounce?: number }): MarkdownPage {
         return useFileMetadata(this.core, this.path, settings) as MarkdownPage;
     }
@@ -235,6 +241,7 @@ export class DatacoreLocalApi {
     }
 
     /** Use the file metadata for a specific file. Automatically updates the view when the file changes. */
+    public useFile<T extends Indexable = Indexable>(path: string, settings?: { debounce?: number }): T | undefined;
     public useFile(path: string, settings?: { debounce?: number }): Indexable | undefined {
         return useFileMetadata(this.core, path, settings);
     }
@@ -248,11 +255,16 @@ export class DatacoreLocalApi {
      * Run a query, automatically re-running it whenever the vault changes. Returns more information about the query
      * execution, such as index revision and total search duration.
      */
+    public useFullQuery<T extends Indexable = Indexable>(
+        query: string | IndexQuery,
+        settings?: { debounce?: number }
+    ): SearchResult<T>;
     public useFullQuery(query: string | IndexQuery, settings?: { debounce?: number }): SearchResult<Indexable> {
         return useFullQuery(this.core, this.parseQuery(query), settings);
     }
 
     /** Run a query, automatically re-running it whenever the vault changes. */
+    public useQuery<T extends Indexable = Indexable>(query: string | IndexQuery, settings?: { debounce?: number }): T[];
     public useQuery(query: string | IndexQuery, settings?: { debounce?: number }): Indexable[] {
         // Hooks need to be called in a consistent order, so we don't nest the `useQuery` call in the DataArray.wrap _just_ in case.
         return useQuery(this.core, this.parseQuery(query), settings);

--- a/src/index/types/canvas.ts
+++ b/src/index/types/canvas.ts
@@ -26,6 +26,8 @@ import {
 import { InlineField, jsonInlineField, valueInlineField } from "index/import/inline-field";
 import { File } from "index/types/indexable";
 import { mapObjectValues } from "utils/data";
+import { Literal } from "expression/literal";
+import { TypedFieldbearing } from "./typed-field";
 
 /** A canvas file, consisting of a set of canvas cards. */
 export class Canvas implements Linkable, File, Linkbearing, Taggable, Indexable, Fieldbearing {
@@ -121,6 +123,13 @@ export class Canvas implements Linkable, File, Linkbearing, Taggable, Indexable,
         Extractors.inlineFields((f) => f.$infields),
         Extractors.intrinsics()
     );
+}
+
+/** @public */
+export namespace Canvas {
+    export interface Typed<Fields extends { [key in string]?: Literal }>
+        extends Omit<Canvas, keyof TypedFieldbearing<Fields>>,
+            TypedFieldbearing<Fields> {}
 }
 
 /** All supported canvas card types. */
@@ -231,6 +240,13 @@ export class CanvasTextCard extends BaseCanvasCard implements Linkbearing, Tagga
         Extractors.inlineFields((f) => f.$infields),
         Extractors.frontmatter((f) => f.$frontmatter)
     );
+}
+
+/** @public */
+export namespace CanvasTextCard {
+    export interface Typed<Fields extends { [key in string]?: Literal }>
+        extends Omit<CanvasTextCard, keyof TypedFieldbearing<Fields>>,
+            TypedFieldbearing<Fields> {}
 }
 
 /** Canvas card that is just a file embedding. */

--- a/src/index/types/markdown.ts
+++ b/src/index/types/markdown.ts
@@ -31,6 +31,7 @@ import {
 } from "./json/markdown";
 import { mapObjectValues } from "utils/data";
 import { JsonConversion } from "./json/common";
+import { TypedValuebearing } from "./typed-field";
 
 /** @public A markdown file in the vault; the source of most metadata. */
 export class MarkdownPage implements File, Linkbearing, Taggable, Indexable, Fieldbearing {
@@ -156,6 +157,13 @@ export class MarkdownPage implements File, Linkbearing, Taggable, Indexable, Fie
     );
 }
 
+/** @public */
+export namespace MarkdownPage {
+    export interface Typed<Fields extends { [key in string]?: Literal }>
+        extends Omit<MarkdownPage, keyof TypedValuebearing<Fields>>,
+            TypedValuebearing<Fields> {}
+}
+
 /** @public A single markdown section inside of a page. */
 export class MarkdownSection implements Indexable, Taggable, Linkable, Linkbearing, Fieldbearing {
     /** All of the types that a markdown section is. */
@@ -261,6 +269,13 @@ export class MarkdownSection implements Indexable, Taggable, Linkable, Linkbeari
     }
 }
 
+/** @public */
+export namespace MarkdownSection {
+    export interface Typed<Fields extends { [key in string]?: Literal }>
+        extends Omit<MarkdownSection, keyof TypedValuebearing<Fields>>,
+            TypedValuebearing<Fields> {}
+}
+
 /** @public Base class for all markdown blocks. */
 export class MarkdownBlock implements Indexable, Linkbearing, Taggable, Fieldbearing {
     static TYPES = ["markdown", "block", LINKBEARING_TYPE, TAGGABLE_TYPE, FIELDBEARING_TYPE];
@@ -356,6 +371,13 @@ export class MarkdownBlock implements Indexable, Linkbearing, Taggable, Fieldbea
     }
 }
 
+/** @public */
+export namespace MarkdownBlock {
+    export interface Typed<Fields extends { [key in string]?: Literal }>
+        extends Omit<MarkdownBlock, keyof TypedValuebearing<Fields>>,
+            TypedValuebearing<Fields> {}
+}
+
 /** @public Special block for markdown lists (of either plain list entries or tasks). */
 export class MarkdownListBlock extends MarkdownBlock implements Taggable, Linkbearing {
     static TYPES = ["markdown", "block", "block-list", TAGGABLE_TYPE, LINKBEARING_TYPE, FIELDBEARING_TYPE];
@@ -398,6 +420,13 @@ export class MarkdownListBlock extends MarkdownBlock implements Taggable, Linkbe
     public constructor(init: Partial<MarkdownListBlock>) {
         super(init);
     }
+}
+
+/** @public */
+export namespace MarkdownListBlock {
+    export interface Typed<Fields extends { [key in string]?: Literal }>
+        extends Omit<MarkdownListBlock, keyof TypedValuebearing<Fields>>,
+            TypedValuebearing<Fields> {}
 }
 
 /** @public A block containing markdown code. */
@@ -469,6 +498,13 @@ export class MarkdownCodeblock extends MarkdownBlock implements Indexable, Field
     );
 }
 
+/** @public */
+export namespace MarkdownCodeblock {
+    export interface Typed<Fields extends { [key in string]?: Literal }>
+        extends Omit<MarkdownCodeblock, keyof TypedValuebearing<Fields>>,
+            TypedValuebearing<Fields> {}
+}
+
 /** @public A data-annotated YAML codeblock. */
 export class MarkdownDatablock extends MarkdownBlock implements Indexable, Fieldbearing, Linkbearing {
     static TYPES = ["markdown", "block", "datablock", TAGGABLE_TYPE, LINKBEARING_TYPE, FIELDBEARING_TYPE];
@@ -536,6 +572,13 @@ export class MarkdownDatablock extends MarkdownBlock implements Indexable, Field
         MarkdownBlock.FIELD_DEF,
         Extractors.frontmatter((f) => f.$data)
     );
+}
+
+/** @public */
+export namespace MarkdownDatablock {
+    export interface Typed<Fields extends { [key in string]?: Literal }>
+        extends Omit<MarkdownDatablock, keyof TypedValuebearing<Fields>>,
+            TypedValuebearing<Fields> {}
 }
 
 /** @public A specific list item in a list. */
@@ -669,6 +712,13 @@ export class MarkdownListItem implements Indexable, Linkbearing, Taggable, Field
     }
 }
 
+/** @public */
+export namespace MarkdownListItem {
+    export interface Typed<Fields extends { [key in string]?: Literal }>
+        extends Omit<MarkdownListItem, keyof TypedValuebearing<Fields>>,
+            TypedValuebearing<Fields> {}
+}
+
 /** @public A specific task inside of a markdown list. */
 export class MarkdownTaskItem extends MarkdownListItem implements Indexable, Linkbearing, Taggable, Fieldbearing {
     static TYPES = ["markdown", "list-item", "task", LINKBEARING_TYPE, TAGGABLE_TYPE, FIELDBEARING_TYPE];
@@ -714,6 +764,13 @@ export class MarkdownTaskItem extends MarkdownListItem implements Indexable, Lin
     public get $completed() {
         return this.$status === "x" || this.$status === "X";
     }
+}
+
+/** @public */
+export namespace MarkdownTaskItem {
+    export interface Typed<Fields extends { [key in string]?: Literal }>
+        extends Omit<MarkdownTaskItem, keyof TypedValuebearing<Fields>>,
+            TypedValuebearing<Fields> {}
 }
 
 /** @public An entry in the frontmatter; includes the raw value, parsed value, and raw key (before lower-casing). */

--- a/src/index/types/typed-field.ts
+++ b/src/index/types/typed-field.ts
@@ -1,0 +1,28 @@
+import { Field } from "expression/field";
+import { Literal } from "expression/literal";
+
+interface TypedField<
+    Fields extends { [key in string]?: Literal } = { [key in string]?: Literal },
+    T extends keyof Fields & string = keyof Fields & string
+> extends Field {
+    /** The value of the field. */
+    value: Exclude<Fields[T], undefined>;
+}
+
+type KeyedField<
+    Fields extends { [key in string]?: Literal },
+    Key extends keyof Fields & string
+> = undefined extends Fields[Key] ? TypedField<Fields, Key> | undefined : TypedField<Fields, Key>;
+
+export interface TypedValuebearing<Fields extends { [key in string]?: Literal }> extends TypedFieldbearing<Fields> {
+    /** Get the value for the given field. */
+    value<Key extends keyof Fields & string>(key: Key): Fields[Key];
+}
+
+export interface TypedFieldbearing<Fields extends { [key in string]?: Literal }> {
+    /** Return a list of all fields. This may be computed eagerly, so cache this value for repeated operations. */
+    fields: TypedField<Fields>[];
+
+    /** Fetch a field with the given name if it is present on this object. */
+    field<Key extends keyof Fields & string>(key: Key): KeyedField<Fields, Key>;
+}


### PR DESCRIPTION
I've made the query functions (query, useQuery, useCurrentFile, etc.) accept a generic to specify its return type, much like the built-in querySelector type.

To make that more useful, I also added a way to specify the types of fields in classes with fields, useful in cases where you know what fields pages or sections returned by the query has. For example:

```typescript
type PersonPage = MarkdownPage.Typed<{ name: string, age: number }>;

return function View() {
  const person = dc.useCurrentFile<PersonPage>();

  // Automatically typed as string
  const name = person.value("name");

  // Automatically typed as number
  const age = person.value("age");

  // Error: Argument of type '"height"' is not assignable to parameter of type '"name" | "age"'
  console.log(person.value("height"));

  return `${name}, ${age} years old`;
}
```