### PR TITLE
Add `__filename` and `__dirname` variables to JavaScript views

### DIFF
--- a/src/ui/javascript.tsx
+++ b/src/ui/javascript.tsx
@@ -36,6 +36,8 @@ export class DatacoreJSRenderer extends MarkdownRenderChild {
                     dc: this.api,
                     h: h,
                     Fragment: Fragment,
+                    __filename: this.path,
+                    __dirname: this.path.split("/").slice(0, -1).join("/"),
                 })) as Promise<Literal | VNode | Function>;
             };
 


### PR DESCRIPTION
Add `__filename` and `__dirname` variables to JavaScript views

Adds Node's `__filename` and `__dirname` variables to Datacore's JavaScript views and `dc.require`d scripts. These new variables make relative script imports possible, by doing the following:

```javascript
// util.js
return { getNumber: () => 2 };

// script1/util.js
return { getNumber: () => 1 };

// script1/main.jsx
const { getNumber } = await dc.require(dc.resolvePath("util.js", __filename));

return function View() {
  // Correctly displays "1 = 1";
  return <p>{getNumber()} = 1</p>
}
```