### PR TITLE
Rename `row` to `$row` in docs and comments

### DIFF
--- a/docs/docs/data/blocks.md
+++ b/docs/docs/data/blocks.md
@@ -25,7 +25,7 @@ Inline fields on blocks can be loaded using the [field syntax](fields):
 ```js
 // In queries and expressions, you can just reference the field directly:
 @block and genre = "Fantasy"
-@block and row["last reviewed"] > date(now) - dur(7d)
+@block and $row["last reviewed"] > date(now) - dur(7d)
 
 // In javascript, use the field API:
 block.value("last reviewed")

--- a/docs/docs/data/fields.md
+++ b/docs/docs/data/fields.md
@@ -25,8 +25,8 @@ You can reference fields directly by name in queries and datacore expressions. T
 // You can also reference intrinsic fields (fields prefixed with `$`):
 @block and $tags.contains("#test")
 
-// Use the implicit 'row' in order to handle fields with spaces in their names:
-@section and row["last reviewed"] >= date(now) - dur(7d)
+// Use the implicit '$row' in order to handle fields with spaces in their names:
+@section and $row["last reviewed"] >= date(now) - dur(7d)
 ```
 
 ## In Javascript

--- a/docs/docs/data/pages.md
+++ b/docs/docs/data/pages.md
@@ -35,7 +35,7 @@ You can reference page fields in queries and expressions directly by case-insens
 
 ```js
 @page and rating >= 7
-@page and row["spaced field"].contains("thing")
+@page and $row["spaced field"].contains("thing")
 ```
 
 ## In Javascript

--- a/docs/docs/data/sections.md
+++ b/docs/docs/data/sections.md
@@ -26,7 +26,7 @@ Inline fields on sections can be loaded using the [field syntax](fields):
 
 ```js
 // In queries and expressions, you can just reference the field directly:
-@section and row["last reviewed"] > date(now) - dur(7d)
+@section and $row["last reviewed"] > date(now) - dur(7d)
 
 // In javascript, use the field API:
 section.value("last reviewed")

--- a/src/expression/expression.ts
+++ b/src/expression/expression.ts
@@ -149,11 +149,11 @@ export namespace Expressions {
         return op == "<=" || op == "<" || op == ">" || op == ">=" || op == "!=" || op == "=";
     }
 
-    /** Returns a set of all unbound variables (i.e., variables not provided by `row`, lambdas, or similar.) */
+    /** Returns a set of all unbound variables (i.e., variables not provided by `$row`, lambdas, or similar.) */
     export function unboundVariables(expr: Expression, bound: Set<string> = new Set([ROW])): Set<string> {
         switch (expr.type) {
             case "binaryop":
-                // Special case `row["...."]`.
+                // Special case `$row["...."]`.
                 if (
                     expr.op === "index" &&
                     expr.left.type == "variable" &&


### PR DESCRIPTION
The `row` variable in expressions [was renamed](https://github.com/blacksmithgu/datacore/commit/39a3445573aadecfcbac31ecd8784bb29015f0fd#diff-78c720f3ffed623b1c0207c81b4819f1cfa7187713945cc348b6e4edebc189d4R83-R84) to `$row` a little over a year ago, but the docs were not changed to match that, so I changed them now.