### PR TITLE
fix: safe access for potentially missing canvas index and caches

### DIFF
--- a/src/index/import/canvas.ts
+++ b/src/index/import/canvas.ts
@@ -26,11 +26,7 @@ export function canvasImport(
     for (const c of parsed.nodes) {
         if (c.type == "group") continue;
         if (c.type == "text") {
-            const { frontmatter, metadata, lines, sections } = markdownSourceImport(
-                path,
-                c.text,
-                index.caches[c.id] ?? {}
-            );
+            const { frontmatter, metadata, lines, sections } = markdownSourceImport(path, c.text, index.caches[c.id] ?? {});
             const card = new CanvasCardData(path, c.id, c, frontmatter);
             sections.forEach((i) => card.section(i));
             canvas.card(card);

--- a/src/index/import/canvas.ts
+++ b/src/index/import/canvas.ts
@@ -50,7 +50,7 @@ abstract class AbstractCanvasCardData {
         public path: string,
         public id: string,
         protected nodeJson: CanvasTextData | CanvasLinkData | CanvasFileData
-    ) { }
+    ) {}
 
     public build(): JsonBaseCanvasCard {
         return {
@@ -120,7 +120,7 @@ export class CanvasData {
     public cards: CanvasCardData[] = [];
     public metadata: Metadata = new Metadata();
 
-    public constructor(public path: string, public stats: FileStats) { }
+    public constructor(public path: string, public stats: FileStats) {}
 
     public card(d: CanvasCardData): CanvasCardData {
         this.cards.push(d);

--- a/src/index/import/canvas.ts
+++ b/src/index/import/canvas.ts
@@ -26,7 +26,11 @@ export function canvasImport(
     for (const c of parsed.nodes) {
         if (c.type == "group") continue;
         if (c.type == "text") {
-            const { frontmatter, metadata, lines, sections } = markdownSourceImport(path, c.text, index.caches[c.id]);
+            const { frontmatter, metadata, lines, sections } = markdownSourceImport(
+                path,
+                c.text,
+                index.caches[c.id] ?? ({} as any)
+            );
             const card = new CanvasCardData(path, c.id, c, frontmatter);
             sections.forEach((i) => card.section(i));
             canvas.card(card);
@@ -50,7 +54,7 @@ abstract class AbstractCanvasCardData {
         public path: string,
         public id: string,
         protected nodeJson: CanvasTextData | CanvasLinkData | CanvasFileData
-    ) {}
+    ) { }
 
     public build(): JsonBaseCanvasCard {
         return {
@@ -120,7 +124,7 @@ export class CanvasData {
     public cards: CanvasCardData[] = [];
     public metadata: Metadata = new Metadata();
 
-    public constructor(public path: string, public stats: FileStats) {}
+    public constructor(public path: string, public stats: FileStats) { }
 
     public card(d: CanvasCardData): CanvasCardData {
         this.cards.push(d);

--- a/src/index/import/canvas.ts
+++ b/src/index/import/canvas.ts
@@ -26,7 +26,11 @@ export function canvasImport(
     for (const c of parsed.nodes) {
         if (c.type == "group") continue;
         if (c.type == "text") {
-            const { frontmatter, metadata, lines, sections } = markdownSourceImport(path, c.text, index.caches[c.id] ?? ({} as any));
+            const { frontmatter, metadata, lines, sections } = markdownSourceImport(
+                path,
+                c.text,
+                index.caches[c.id] ?? {}
+            );
             const card = new CanvasCardData(path, c.id, c, frontmatter);
             sections.forEach((i) => card.section(i));
             canvas.card(card);

--- a/src/index/import/canvas.ts
+++ b/src/index/import/canvas.ts
@@ -26,11 +26,7 @@ export function canvasImport(
     for (const c of parsed.nodes) {
         if (c.type == "group") continue;
         if (c.type == "text") {
-            const { frontmatter, metadata, lines, sections } = markdownSourceImport(
-                path,
-                c.text,
-                index.caches[c.id] ?? ({} as any)
-            );
+            const { frontmatter, metadata, lines, sections } = markdownSourceImport(path, c.text, index.caches[c.id] ?? ({} as any));
             const card = new CanvasCardData(path, c.id, c, frontmatter);
             sections.forEach((i) => card.section(i));
             canvas.card(card);

--- a/src/index/web-worker/importer.ts
+++ b/src/index/web-worker/importer.ts
@@ -108,7 +108,10 @@ export class FileImporter extends Component {
                         path: file.path,
                         contents: contents,
                         stat: file.stat,
-                        index: (this.fileManager as any).linkUpdaters?.canvas?.canvas?.index?.index?.[file.path] ?? { caches: {}, embeds: [], },
+                        index: this.fileManager.linkUpdaters?.canvas?.canvas?.index?.index?.[file.path] ?? {
+                            caches: {},
+                            embeds: [],
+                        },
                     } as CanvasImport);
                     break;
                 }

--- a/src/index/web-worker/importer.ts
+++ b/src/index/web-worker/importer.ts
@@ -108,7 +108,10 @@ export class FileImporter extends Component {
                         path: file.path,
                         contents: contents,
                         stat: file.stat,
-                        index: this.fileManager.linkUpdaters.canvas.canvas.index.index[file.path],
+                        index: (this.fileManager as any).linkUpdaters?.canvas?.canvas?.index?.index?.[file.path] ?? {
+                            caches: {},
+                            embeds: [],
+                        },
                     } as CanvasImport);
                     break;
                 }

--- a/src/index/web-worker/importer.ts
+++ b/src/index/web-worker/importer.ts
@@ -108,10 +108,7 @@ export class FileImporter extends Component {
                         path: file.path,
                         contents: contents,
                         stat: file.stat,
-                        index: (this.fileManager as any).linkUpdaters?.canvas?.canvas?.index?.index?.[file.path] ?? {
-                            caches: {},
-                            embeds: [],
-                        },
+                        index: (this.fileManager as any).linkUpdaters?.canvas?.canvas?.index?.index?.[file.path] ?? { caches: {}, embeds: [], },
                     } as CanvasImport);
                     break;
                 }

--- a/src/typings/obsidian-ex.d.ts
+++ b/src/typings/obsidian-ex.d.ts
@@ -6,11 +6,11 @@ import "obsidian";
 /** Provides extensions used by datacore or provider to other plugins via datacore. */
 declare module "obsidian" {
     interface FileManager {
-        linkUpdaters: {
-            canvas: {
-                canvas: {
-                    index: {
-                        index: CanvasMetadataIndex;
+        linkUpdaters?: {
+            canvas?: {
+                canvas?: {
+                    index?: {
+                        index?: CanvasMetadataIndex;
                     };
                 };
             };


### PR DESCRIPTION
## Summary
This PR fixes a TypeError: Cannot read properties of undefined (reading 'canvas') that occurs during background file reloading and improves type safety by removing any casts.

## The Problem
The plugin assumed this.fileManager.linkUpdaters.canvas always existed. In some environments, this path is undefined, causing a crash during file import.
The code relied on as any casting to access internal Obsidian APIs, hiding potential type issues.
## The Fix
Runtime Safety: Added optional chaining (?.) and fallback objects in src/index/web-worker/importer.ts and src/index/import/canvas.ts.
Type Safety: Extended src/typings/obsidian-ex.d.ts to correctly type the internal linkUpdaters structure, removing the need for as any casting.
This ensures the plugin handles missing internal API data gracefully and adheres to better TypeScript practices.

Use this updated description when you update the PR on GitHub! Make sure you pushed the commits first.

Once you're done with the fix branch, we can switch back to feature/quick-launch to finish verifying that feature.

