### PR TITLE
Bugfix #177 Match list item block IDs in `$cleantext` according to Obsidian spec

### DIFF
--- a/src/index/types/markdown.ts
+++ b/src/index/types/markdown.ts
@@ -664,12 +664,10 @@ export class MarkdownListItem implements Indexable, Linkbearing, Taggable, Field
 
         return (
             this.$text
-                // Capture three groups:
-                // 1) all characters up until group 2 or 3 is encountered
-                // 2) zero or more inline fields
-                // 3) zero or one id,
-                // and replace it with just group 1
-                .replace(/(.*?)([\[\(][^:(\[]+::\s*.*?[\]\)]\s*)*(\^.+){0,1}$/gm, "$1")
+                // Remove any valid block ID, keeping preceding whitespace.
+                .replace(/(\s)\^[a-zA-Z0-9\-]+$/u, "$1")
+                // Keep everything before the first inline field, or everything if there isn't one.
+                .split(/[\[\(][^:\(\[]+::\s*.*?[\]\)]/u)[0]
                 // Trim whitespace.
                 .trim()
         );


### PR DESCRIPTION
Fix to #177. Fixed how list item `$cleantext` matches block IDs, as block links within a list item text were erroneously culled.

Block IDs at the end of lines need leading whitespace, no trailing whitespace, and contain only Latin letters, numbers, or hyphens [^1]. I also split the cleaning operation between removing the block ID and removing everything after and including the first inline field.

I also changed the flags used in the regex patterns. Previous pattern used `/gm`, which I removed:

- Don't need `/m`, especially since `$text` is only one line, but if multiline list items were to be supported by Datacore in the future, we would only want to match block IDs at the end of the block, not at the end of a line.
- Don't need `/g`, since the block ID can only match once anyways and using `/g` inside `split()` is redundant.

I added the `/u` flag for Unicode support, since we can expect Unicode input. Ideally we could use the `/v` flag but we have to target ES2024 or higher for that. The `/v` flag supersedes `/u` and makes some breaking changes to how special characters in character classes are handled [^2]. Basically, they have to be escaped whereas this ambiguity was allowed before. I made these patterns future compatible if we do upgrade and adopt the `/v` flag in the future.

The pattern for inline fields is flawed, but that will be a lot of work beyond this bug fix. I am keeping this PR small for now.

[^1]: https://obsidian.md/help/links#Link+to+a+block+in+a+note
[^2]: https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag