### PR TITLE
Bug fix: Make object revision match datastore revision

### DIFF
--- a/src/index/datastore.ts
+++ b/src/index/datastore.ts
@@ -116,7 +116,7 @@ export class Datastore {
      * added to the object.
      */
     public store<T extends Indexable>(object: T | T[], substorer?: Substorer<T>) {
-        this._recursiveStore(object, this.revision++, substorer, undefined);
+        this._recursiveStore(object, ++this.revision, substorer, undefined);
     }
 
     /** Recursively store objects using a potential subindexer. */

--- a/src/index/types/markdown.ts
+++ b/src/index/types/markdown.ts
@@ -664,12 +664,10 @@ export class MarkdownListItem implements Indexable, Linkbearing, Taggable, Field
 
         return (
             this.$text
-                // Capture three groups:
-                // 1) all characters up until group 2 or 3 is encountered
-                // 2) zero or more inline fields
-                // 3) zero or one id,
-                // and replace it with just group 1
-                .replace(/(.*?)([\[\(][^:(\[]+::\s*.*?[\]\)]\s*)*(\^.+){0,1}$/gm, "$1")
+                // Remove any valid block ID, keeping preceding whitespace.
+                .replace(/(\s)\^[a-zA-Z0-9\-]+$/u, "$1")
+                // Keep everything before the first inline field, or everything if there isn't one.
+                .split(/[\[\(][^:\(\[]+::\s*.*?[\]\)]/u)[0]
                 // Trim whitespace.
                 .trim()
         );


### PR DESCRIPTION
Fixes #179.

Upon changes in the vault, the revision of any newly-modified object matches that of the datastore.

I have hand-tested this in a vault with the following datacore block while editing another page in a split view. I compared the results before and after this change.

```jsx
return function View() {
    const revision = dc.useIndexUpdates();
    const pages = dc.useMemo(
        () => dc.query(`@page and $revision >= ${revision - 1}`),
        [revision]
    );
    
    return <>
        Revision: {revision}
        <dc.List
            rows={pages}
            renderer={page => `${page.$path}: ${page.$revision}`}
        />
    </>
}
```

PS: Could someone explain the proper way to work with feature branches on a fork when fixing bugs? As you can see, this PR contains two redundant commits relating to my last bugfix. I made my last bugfix on a feature branch that got merged into this repo's main. That merge commit was then pulled into in my fork's main branch as expected. To get rid of that last feature branch, I just merged it into my main and deleted it, since that's what I normally do. But now, since this PR's branch is based on that, those merge commits (not squashed, but that's only part of the issue) are included, even thought they're redundant.